### PR TITLE
[TSS-169] Use HivePeople fork of AsyncEx

### DIFF
--- a/Async.Model.UnitTest/Async.Model.UnitTest.csproj
+++ b/Async.Model.UnitTest/Async.Model.UnitTest.csproj
@@ -45,15 +45,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.3.0.1-pre\lib\net45\Nito.AsyncEx.dll</HintPath>
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1-zhivepeople\lib\net45\Nito.AsyncEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.3.0.1-pre\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1-zhivepeople\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.3.0.1-pre\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1-zhivepeople\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">

--- a/Async.Model.UnitTest/packages.config
+++ b/Async.Model.UnitTest/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FluentAssertions" version="3.4.0" targetFramework="net45" />
   <package id="MSFT.ParallelExtensionsExtras" version="1.2.0" targetFramework="net45" userInstalled="true" />
-  <package id="Nito.AsyncEx" version="3.0.1-pre" targetFramework="net45" />
+  <package id="Nito.AsyncEx" version="3.0.1-zhivepeople" targetFramework="net45" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" userInstalled="true" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" userInstalled="true" />

--- a/Async.Model/Async.Model.csproj
+++ b/Async.Model/Async.Model.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.3.0.1-pre\lib\portable-net45+netcore45+wp8+wpa81\Nito.AsyncEx.dll</HintPath>
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1-zhivepeople\lib\portable-net45+netcore45+wp8+wpa81\Nito.AsyncEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Async.Model/packages.config
+++ b/Async.Model/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nito.AsyncEx" version="3.0.1-pre" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Nito.AsyncEx" version="3.0.1-zhivepeople" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
 </packages>


### PR DESCRIPTION
Since AsyncEx version 3.0.1-pre is available on nuget.org, the build would get the wrong version when nuget.org was set as the first package source. Guard against this by making a HivePeople-specific prerelease version and use it in dependent projects.
