### PR TITLE
[TSS-131] Changed semantics and new simple thread-safe async loader

### DIFF
--- a/Async.Model.UnitTest/AsyncLoaded/AsyncLoaderBaseTest.cs
+++ b/Async.Model.UnitTest/AsyncLoaded/AsyncLoaderBaseTest.cs
@@ -536,12 +536,12 @@ namespace Async.Model.UnitTest.AsyncLoaded
 
             public Task PerformAsyncOperation(Func<CancellationToken, Task<bool>> operation)
             {
-                return base.PerformAsyncOperation(operation, (b, c) => b);
+                return base.PerformAsyncOperation(() => { }, operation, (b, c) => b);
             }
 
             public Task PerformAsyncOperation(Func<CancellationToken, Task<bool>> operation, Func<bool, CancellationToken, bool> processResult)
             {
-                return base.PerformAsyncOperation(operation, processResult);
+                return base.PerformAsyncOperation(() => { }, operation, processResult);
             }
 
             public void NotifySpecialOperationCompletedTunnel(bool result)

--- a/Async.Model.UnitTest/SeqTest.cs
+++ b/Async.Model.UnitTest/SeqTest.cs
@@ -221,6 +221,11 @@ namespace Async.Model.UnitTest
                 innerList = newItems.ToImmutableList();
             }
 
+            public void Clear()
+            {
+                innerList = innerList.Clear();
+            }
+
             public IEnumerator<T> GetEnumerator()
             {
                 return innerList.GetEnumerator();

--- a/Async.Model/Async.Model.csproj
+++ b/Async.Model/Async.Model.csproj
@@ -38,6 +38,7 @@
     <Compile Include="AsyncLoaded\AsyncLoaderBase.cs" />
     <Compile Include="AsyncLoaded\IAsyncItemLoader.cs" />
     <Compile Include="AsyncLoaded\IAsyncCollectionLoader.cs" />
+    <Compile Include="AsyncLoaded\ThreadSafeAsyncLoader.cs" />
     <Compile Include="AsyncLoader.cs" />
     <Compile Include="IAsyncCollection.cs" />
     <Compile Include="EntityTag.cs" />

--- a/Async.Model/AsyncLoaded/AsyncItemLoader.cs
+++ b/Async.Model/AsyncLoaded/AsyncItemLoader.cs
@@ -46,13 +46,14 @@ namespace Async.Model.AsyncLoaded
 
         public Task LoadAsync()
         {
-            return PerformAsyncOperation(loadAsync, ProcessItemUnderLock);
+            // TODO: Should we follow behaviour of AsyncLoader and clear item during load?
+            return PerformAsyncOperation(() => { }, loadAsync, ProcessItemUnderLock);
         }
 
         public Task UpdateAsync()
         {
             var it = Item;  // read under lock
-            return PerformAsyncOperation(token => updateAsync(it, token), ProcessItemUnderLock);
+            return PerformAsyncOperation(() => { }, token => updateAsync(it, token), ProcessItemUnderLock);
         }
 
         private Tuple<T, T> ProcessItemUnderLock(T newItem, CancellationToken cancellationToken)

--- a/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
+++ b/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Async.Model.Sequence;
+
+namespace Async.Model.AsyncLoaded
+{
+    public sealed class ThreadSafeAsyncLoader<TItem> : AsyncLoader<TItem>
+    {
+        public ThreadSafeAsyncLoader(
+            Func<IEnumerable<TItem>, ISeq<TItem>> seqFactory,
+            Func<CancellationToken, Task<IEnumerable<TItem>>> loadDataAsync = null,
+            Func<IEnumerable<TItem>, CancellationToken, Task<IEnumerable<ItemChange<TItem>>>> fetchUpdatesAsync = null,
+            CancellationToken rootCancellationToken = default(CancellationToken),
+            TaskScheduler eventScheduler = null) : base(seqFactory, loadDataAsync, fetchUpdatesAsync, rootCancellationToken, eventScheduler)
+        {
+            // Do nothing: base constructor handles everything
+        }
+
+        public override TItem Take()
+        {
+            using (mutex.Lock())
+            {
+                return base.Take();
+            }
+        }
+
+        public override void Conj(TItem item)
+        {
+            using (mutex.Lock())
+            {
+                base.Conj(item);
+            }
+        }
+
+        public override void ReplaceAll(IEnumerable<TItem> newItems)
+        {
+            using (mutex.Lock())
+            {
+                base.ReplaceAll(newItems);
+
+            }
+        }
+
+        public override void Clear()
+        {
+            using (mutex.Lock())
+            {
+                base.Clear(); 
+            }
+        }
+
+        public override IEnumerator<TItem> GetEnumerator()
+        {
+            using (mutex.Lock())
+            {
+                // Take a snapshot under lock and return an enumerator of the snapshot
+                return seq.ToList().GetEnumerator();
+            }
+        }
+
+        public override Task<TItem> TakeAsync(CancellationToken cancellationToken)
+        {
+            // TODO: Confirm that it doesn't make sense
+            throw new NotSupportedException("Does not make sense for a locking collection");
+        }
+
+        public override Task ConjAsync(TItem item, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException("Does not make sense for a locking collection");
+        }
+    }
+}

--- a/Async.Model/Sequence/ISeq.cs
+++ b/Async.Model/Sequence/ISeq.cs
@@ -33,5 +33,10 @@ namespace Async.Model.Sequence
         /// </summary>
         /// <param name="newItems">New items to replace the existing items in the sequence.</param>
         void ReplaceAll(IEnumerable<T> newItems);
+
+        /// <summary>
+        /// Clears the sequence, leaving it empty. If the seq is thread-safe, this operation is required to be atomic.
+        /// </summary>
+        void Clear();
     }
 }

--- a/Async.Model/Sequence/Seq.cs
+++ b/Async.Model/Sequence/Seq.cs
@@ -46,6 +46,11 @@ namespace Async.Model.Sequence
                 list.AddRange(newItems);
             }
 
+            public void Clear()
+            {
+                list.Clear();
+            }
+
             public IEnumerator<T> GetEnumerator()
             {
                 return list.GetEnumerator();
@@ -87,6 +92,11 @@ namespace Async.Model.Sequence
             public void ReplaceAll(IEnumerable<T> newItems)
             {
                 this.queue = new Queue<T>(newItems);
+            }
+
+            public void Clear()
+            {
+                queue.Clear();
             }
 
             public IEnumerator<T> GetEnumerator()
@@ -141,6 +151,11 @@ namespace Async.Model.Sequence
             public void ReplaceAll(IEnumerable<T> newItems)
             {
                 innerSeq.ReplaceAll(newItems);
+            }
+
+            public void Clear()
+            {
+                innerSeq.Clear();
             }
 
             public IEnumerator<T> GetEnumerator()


### PR DESCRIPTION
- add: a seq can now be emptied via new method Clear()
- add: AsyncLoaderBase.PerformAsyncOperation now takes a preparatory action to
      run before the async operation
- change: AsyncLoader.LoadAsync now clears the seq before loading data; this
      clarifies the use: a load happens only at start of a user session;
  solves some thorny issues with Conj and LoadAsync
- change: loaded items are now concatenated with existing items in the seq
      instead of replacing them
- add: PerformAsyncOperation and LoadAsync are now fully documented
- add: a thread-safe subclass of AsyncLoader that ensures safety by using
      locking; thus, the underlying seq does not need to be thread-safe
