### PR TITLE
[TSS-131] Added a Replace method to sequences

### DIFF
--- a/Async.Model.UnitTest/Async.Model.UnitTest.csproj
+++ b/Async.Model.UnitTest/Async.Model.UnitTest.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Fluent.cs" />
     <Compile Include="FullOuterJoinTest.cs" />
     <Compile Include="GenericContravarianceTest.cs" />
+    <Compile Include="LookupTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SeqTest.cs" />
   </ItemGroup>

--- a/Async.Model.UnitTest/LookupTest.cs
+++ b/Async.Model.UnitTest/LookupTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Async.Model.UnitTest
+{
+    /// <summary>
+    /// Someone on Stackoverflow claimed that the ILookup returned from ToLookup does not preserve iteration order of
+    /// input sequence. This test aims to prove that it does indeed preserve iteration order. ToLookup uses the Lookup
+    /// class defined inside System.Linq.Enumeration.cs, which keeps a linked list of groupings in insertion order and
+    /// uses that for iteration.
+    /// </summary>
+    /// <remarks>
+    /// Note that the ILookup interface does not require implementations to respect iteration order of the input
+    /// sequence, so one should be careful about relying on it, since Microsoft could theoretically change it in a
+    /// later version of .NET. In fact they have made another implementation in the System.Linq.Parallel namespace that
+    /// does NOT preserve iteration order, since it is based on a Dictionary.
+    /// </remarks>
+    /// <see cref="http://stackoverflow.com/a/30289550/567000"/>
+    /// <see cref="http://referencesource.microsoft.com/#System.Core/System/Linq/Enumerable.cs,cb695d4a973ef608"/>
+    [TestFixture]
+    public class LookupTest
+    {
+        [Test]
+        public void ToLookupPreservesIterationOrderWithoutComparerForSortedSequence()
+        {
+            // First we show that order is preserved for a sorted sequence
+            var numbers = new[] { 1, 2, 1, 3, 3, 4, 5 };
+            var lookup = numbers.ToLookup(i => i);
+
+            Assert.That(lookup.Select(g => g.Key), Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void ToLookupPreservesIterationOrderWithoutComparerForUnsortedSequence()
+        {
+            // Now show that order is still respected when the input sequence is unsorted
+            var numbers = new[] { 4, 2, 2, 5, 1, 4, 3 };
+            var lookup = numbers.ToLookup(i => i);
+
+            Assert.That(lookup.Select(g => g.Key), Is.EqualTo(new[] { 4, 2, 5, 1, 3 }));
+        }
+
+        class ParityComparer : IEqualityComparer<int>
+        {
+            public bool Equals(int x, int y)
+            {
+                // Coded for clarity, not efficiency
+                bool xIsEven = x % 2 == 0;
+                bool yIsEven = y % 2 == 0;
+
+                return xIsEven == yIsEven;
+            }
+
+            public int GetHashCode(int obj)
+            {
+                // Coded for clarity, not efficiency
+                bool even = obj % 2 == 0;
+                return even.GetHashCode();
+            }
+        }
+
+        [Test]
+        public void ToLookupPreserversIterationOrderWithComparer()
+        {
+            // Now to show that it also works when using an equality comparer
+            var numbers = new[] { 1, 2 };
+            var lookup = numbers.ToLookup(i => i, new ParityComparer());
+
+            Assert.That(lookup.Select(g => g.Key), Is.EqualTo(new[] { 1, 2 }));
+
+            numbers = new[] { 4, 1, 4 };
+            lookup = numbers.ToLookup(i => i, new ParityComparer());
+
+            Assert.That(lookup.Select(g => g.Key), Is.EqualTo(new[] { 4, 1 }));
+        }
+
+        [Test]
+        public void ToLookupPreservesIterationOrderForStrings()
+        {
+            // And when using strings instead of ints
+            var greekLetters = new[] { "alpha", "beta", "gamma" };
+            var lookup = greekLetters.ToLookup(l => l.Substring(0, 1));
+
+            Assert.That(lookup.Select(g => g.Key), Is.EqualTo(new[] { "a", "b", "g" }));
+
+            greekLetters = new[] { "beta", "gamma", "alpha" };
+            lookup = greekLetters.ToLookup(l => l.Substring(0, 1));
+
+            Assert.That(lookup.Select(g => g.Key), Is.EqualTo(new[] { "b", "g", "a" }));
+        }
+    }
+}

--- a/Async.Model.UnitTest/Properties/AssemblyInfo.cs
+++ b/Async.Model.UnitTest/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta2")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta3")]

--- a/Async.Model.UnitTest/Properties/AssemblyInfo.cs
+++ b/Async.Model.UnitTest/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.2")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta1")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta2")]

--- a/Async.Model.UnitTest/SeqTest.cs
+++ b/Async.Model.UnitTest/SeqTest.cs
@@ -216,6 +216,11 @@ namespace Async.Model.UnitTest
                 innerList = innerList.Add(item);
             }
 
+            public void Replace(T item)
+            {
+                innerList = innerList.Replace(item, item);
+            }
+
             public void ReplaceAll(IEnumerable<T> newItems)
             {
                 innerList = newItems.ToImmutableList();

--- a/Async.Model.UnitTest/SeqTest.cs
+++ b/Async.Model.UnitTest/SeqTest.cs
@@ -216,9 +216,9 @@ namespace Async.Model.UnitTest
                 innerList = innerList.Add(item);
             }
 
-            public void Replace(T item)
+            public void Replace(T oldItem, T newItem)
             {
-                innerList = innerList.Replace(item, item);
+                innerList = innerList.Replace(oldItem, newItem);
             }
 
             public void ReplaceAll(IEnumerable<T> newItems)

--- a/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
+++ b/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
@@ -37,11 +37,11 @@ namespace Async.Model.AsyncLoaded
             }
         }
 
-        public override void Replace(TItem newItem)
+        public override void Replace(TItem oldItem, TItem newItem)
         {
             using (mutex.Lock())
             {
-                seq.Replace(newItem);
+                seq.Replace(oldItem, newItem);
                 NotifyCollectionChanged(ChangeType.Updated, newItem);
             }
         }

--- a/Async.Model/AsyncLoader.cs
+++ b/Async.Model/AsyncLoader.cs
@@ -111,6 +111,11 @@ namespace Async.Model
             NotifyCollectionChanged(ChangeType.Added, item);
         }
 
+        public virtual void Replace(TItem newItem)
+        {
+            throw new NotSupportedException("AsyncLoader does not support Replace");
+        }
+
         public virtual void ReplaceAll(IEnumerable<TItem> newItems)
         {
             throw new NotSupportedException("AsyncLoader does not support ReplaceAll");
@@ -178,7 +183,7 @@ namespace Async.Model
         }
         #endregion
 
-        private void NotifyCollectionChanged(ChangeType type, TItem item)
+        protected void NotifyCollectionChanged(ChangeType type, TItem item)
         {
             var changes = new[] { new ItemChange<TItem>(type, item) };
             NotifySpecialOperationCompleted(changes);

--- a/Async.Model/AsyncLoader.cs
+++ b/Async.Model/AsyncLoader.cs
@@ -111,7 +111,7 @@ namespace Async.Model
             NotifyCollectionChanged(ChangeType.Added, item);
         }
 
-        public virtual void Replace(TItem newItem)
+        public virtual void Replace(TItem oldItem, TItem newItem)
         {
             throw new NotSupportedException("AsyncLoader does not support Replace");
         }

--- a/Async.Model/LinqExtensions.cs
+++ b/Async.Model/LinqExtensions.cs
@@ -53,9 +53,6 @@ namespace Async.Model
             Func<TOld, TKey> oldItemKeySelector,
             IEqualityComparer<TKey> identityComparer = null,
             IEqualityComparer<TKey> updateComparer = null)
-            where TNew : class
-            where TOld : class
-            where TKey : class
         {
             if (newItems == null) throw new ArgumentNullException("newItems");
             if (oldItems == null) throw new ArgumentNullException("oldItems");
@@ -75,8 +72,8 @@ namespace Async.Model
                 var newKey = newItemKeySelector(n);
                 var oldKey = oldItemKeySelector(o);
 
-                if (newKey != oldKey && !updateComparer.Equals(newKey, oldKey))
-                    return new ItemChange<TKey>(ChangeType.Updated, newItemKeySelector(n));
+                if (!updateComparer.Equals(newKey, oldKey))
+                    return new ItemChange<TKey>(ChangeType.Updated, newKey);
 
                 return new ItemChange<TKey>(ChangeType.Unchanged, newKey);
 

--- a/Async.Model/LinqExtensions.cs
+++ b/Async.Model/LinqExtensions.cs
@@ -6,6 +6,48 @@ namespace Async.Model
 {
     public static class LinqExtensions
     {
+        /// <summary>
+        /// Returns a new sequence in which all instances of oldItem are replaced with newItem. Instances are compared
+        /// for equality using <c>EqualityComparer&lt;TSource&gt;.Default</c>.
+        /// </summary>
+        /// <remarks>This method is implemented using deferred execution.</remarks>
+        /// <typeparam name="TSource">The type of elements of source.</typeparam>
+        /// <param name="source">A sequence of values in which to replace some items.</param>
+        /// <param name="oldItem">Item to be replaced.</param>
+        /// <param name="newItem">Item to substitute for the old one.</param>
+        /// <returns>A new sequence with all instances of oldItem replaced with newItem.</returns>
+        public static IEnumerable<TSource> Replace<TSource>(this IEnumerable<TSource> source, TSource oldItem, TSource newItem)
+        {
+            return Replace(source, oldItem, newItem, EqualityComparer<TSource>.Default);
+        }
+
+        /// <summary>
+        /// Returns a new sequence in which all instances of oldItem are replaced with newItem. Instances are compared
+        /// for equality using the given comparer.
+        /// </summary>
+        /// <remarks>This method is implemented using deferred execution.</remarks>
+        /// <typeparam name="TSource">The type of elements of source.</typeparam>
+        /// <param name="source">A sequence of values in which to replace some items.</param>
+        /// <param name="oldItem">Item to be replaced.</param>
+        /// <param name="newItem">Item to substitute for the old one.</param>
+        /// <param name="comparer">Comparer to use when matching oldItem against elements of the sequence.</param>
+        /// <returns>A new sequence with all instances of oldItem replaced with newItem.</returns>
+        public static IEnumerable<TSource> Replace<TSource>(
+            this IEnumerable<TSource> source, TSource oldItem, TSource newItem, IEqualityComparer<TSource> comparer)
+        {
+            // TODO: Use nameof operator once we upgrade to C# 6.0
+            if (source == null) throw new ArgumentNullException("source");
+            if (comparer == null) throw new ArgumentNullException("comparer");
+            
+            return source.Select(item =>
+            {
+                if (comparer.Equals(item, oldItem))
+                    return newItem;
+                else
+                    return item;
+            });
+        }
+
         public static IEnumerable<TResult> FullOuterJoin<TLeft, TRight, TKey, TResult>(
             this IEnumerable<TLeft> left,
             IEnumerable<TRight> right,

--- a/Async.Model/Properties/AssemblyInfo.cs
+++ b/Async.Model/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.2")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta1")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta2")]

--- a/Async.Model/Properties/AssemblyInfo.cs
+++ b/Async.Model/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta2")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta3")]

--- a/Async.Model/Sequence/ISeq.cs
+++ b/Async.Model/Sequence/ISeq.cs
@@ -27,15 +27,12 @@ namespace Async.Model.Sequence
         void Conj(T item);
 
         /// <summary>
-        /// Replaces an item in the sequence with the given item. Items are compared by whatever definition of equality
-        /// the seq uses.
+        /// Replaces all instances of <paramref name="oldItem"/> in the sequence with <paramref name="newItem"/>. Items
+        /// are compared by whatever definition of equality the seq uses.
         /// </summary>
-        /// <remarks>
-        /// This method is intended for use with seqs where only a subset of fields are used for equals comparison,
-        /// where it would make sense to use in order to update the remaining fields.
-        /// </remarks>
-        /// <param name="item">The replacement item to use instead of the item in the list that is deemed equal.</param>
-        void Replace(T item);
+        /// <param name="oldItem">The item to be replaced.</param>
+        /// <param name="newItem">The replacement item to use.</param>
+        void Replace(T oldItem, T newItem);
 
         /// <summary>
         /// Replaces all items in the sequence with the given new items. This has the same effect as iterating through

--- a/Async.Model/Sequence/ISeq.cs
+++ b/Async.Model/Sequence/ISeq.cs
@@ -27,6 +27,17 @@ namespace Async.Model.Sequence
         void Conj(T item);
 
         /// <summary>
+        /// Replaces an item in the sequence with the given item. Items are compared by whatever definition of equality
+        /// the seq uses.
+        /// </summary>
+        /// <remarks>
+        /// This method is intended for use with seqs where only a subset of fields are used for equals comparison,
+        /// where it would make sense to use in order to update the remaining fields.
+        /// </remarks>
+        /// <param name="item">The replacement item to use instead of the item in the list that is deemed equal.</param>
+        void Replace(T item);
+
+        /// <summary>
         /// Replaces all items in the sequence with the given new items. This has the same effect as iterating through
         /// newItems and calling Conj for each item, except possibly more efficient. Also, if the seq is thread-safe,
         /// this operation is required to be atomic.

--- a/Async.Model/Sequence/Seq.cs
+++ b/Async.Model/Sequence/Seq.cs
@@ -40,14 +40,15 @@ namespace Async.Model.Sequence
                 return item;
             }
 
-            public void Replace(T item)
+            public void Replace(T oldItem, T newItem)
             {
-                int index = list.IndexOf(item);
+                var comparer = EqualityComparer<T>.Default;
 
-                if (index == -1)
-                    throw new ArgumentException("Not found: " + item, "item");
-
-                list[index] = item;
+                for (int i = 0; i < list.Count; i++)
+                {
+                    if (comparer.Equals(list[i], oldItem))
+                        list[i] = newItem;
+                }
             }
 
             public void ReplaceAll(IEnumerable<T> newItems)
@@ -99,29 +100,9 @@ namespace Async.Model.Sequence
                 return queue.Dequeue();
             }
 
-            public void Replace(T item)
+            public void Replace(T oldItem, T newItem)
             {
-                // Use the same definition of equality as List<T>.IndexOf
-                var comparer = EqualityComparer<T>.Default;
-                bool found = false;
-
-                var filteredQueue = queue.Select(queueEntry =>
-                {
-                    if (comparer.Equals(queueEntry, item))
-                    {
-                        found = true;
-                        return item;
-                    }
-                    else
-                    {
-                        return queueEntry;
-                    }
-                });
-
-                if (!found)
-                    throw new ArgumentException("Not found: " + item, "item");
-
-                ReplaceAll(filteredQueue);
+                ReplaceAll(queue.Replace(oldItem, newItem));
             }
 
             public void ReplaceAll(IEnumerable<T> newItems)
@@ -183,9 +164,9 @@ namespace Async.Model.Sequence
                 innerSeq.Conj(item);
             }
 
-            public void Replace(T item)
+            public void Replace(T oldItem, T newItem)
             {
-                innerSeq.Replace(item);
+                innerSeq.Replace(oldItem, newItem);
             }
 
             public void ReplaceAll(IEnumerable<T> newItems)

--- a/Async.Model/Sequence/Seq.cs
+++ b/Async.Model/Sequence/Seq.cs
@@ -40,6 +40,16 @@ namespace Async.Model.Sequence
                 return item;
             }
 
+            public void Replace(T item)
+            {
+                int index = list.IndexOf(item);
+
+                if (index == -1)
+                    throw new ArgumentException("Not found: " + item, "item");
+
+                list[index] = item;
+            }
+
             public void ReplaceAll(IEnumerable<T> newItems)
             {
                 list.Clear();
@@ -87,6 +97,31 @@ namespace Async.Model.Sequence
             public T Take()
             {
                 return queue.Dequeue();
+            }
+
+            public void Replace(T item)
+            {
+                // Use the same definition of equality as List<T>.IndexOf
+                var comparer = EqualityComparer<T>.Default;
+                bool found = false;
+
+                var filteredQueue = queue.Select(queueEntry =>
+                {
+                    if (comparer.Equals(queueEntry, item))
+                    {
+                        found = true;
+                        return item;
+                    }
+                    else
+                    {
+                        return queueEntry;
+                    }
+                });
+
+                if (!found)
+                    throw new ArgumentException("Not found: " + item, "item");
+
+                ReplaceAll(filteredQueue);
             }
 
             public void ReplaceAll(IEnumerable<T> newItems)
@@ -146,6 +181,11 @@ namespace Async.Model.Sequence
             public void Conj(T item)
             {
                 innerSeq.Conj(item);
+            }
+
+            public void Replace(T item)
+            {
+                innerSeq.Replace(item);
             }
 
             public void ReplaceAll(IEnumerable<T> newItems)


### PR DESCRIPTION
- add: Replace method to ISeq that will replace an item in the seq deemed
  equal to the given item with the given item
- add: test showing that ToLookup respects iteration order
- fix: need to change version in AssemblyInfo.cs, so we can upgrade
  the NuGet package properly in client projects
- add: ThreadSafeAsyncLoader now implements ReplaceAll and Clear methods,
  since they are easy to implement with locking
- change: remove generic constraint on LinqExtensions.ChangesFor, to make
  it more useful
