### PR TITLE
Test loadasync and replace

### DIFF
--- a/Async.Model.TestExtensions/Async.Model.TestExtensions.csproj
+++ b/Async.Model.TestExtensions/Async.Model.TestExtensions.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{44B10DD1-3734-443F-9D74-EB8BEB40CA93}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Async.Model.TestExtensions</RootNamespace>
+    <AssemblyName>Async.Model.TestExtensions</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentAssertions, Version=3.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.4.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.4.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FluentAssertionsExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Async.Model\Async.Model.csproj">
+      <Project>{222ab3c6-bfdb-40bb-b0ba-9c059b1437e3}</Project>
+      <Name>Async.Model</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Async.Model.TestExtensions/FluentAssertionsExtensions.cs
+++ b/Async.Model.TestExtensions/FluentAssertionsExtensions.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+
+namespace Async.Model.TestExtensions
+{
+    public static class FluentAssertionsExtensions
+    {
+        public class ItemChangeAssertions<T>
+        {
+            private static readonly Dictionary<ChangeType, string> changeDescriptions = new Dictionary<ChangeType, string>()
+            {
+                { ChangeType.Added, "addition" },
+                { ChangeType.Removed, "removal" },
+                { ChangeType.Unchanged, "unchanging" },  // TODO: Can we figure out a better description for a "no-op change"?
+                { ChangeType.Updated, "update" }
+            };
+
+            public IItemChange<T> Subject { get; private set; }
+
+            internal ItemChangeAssertions(IItemChange<T> actualItemChange)
+            {
+                this.Subject = actualItemChange;
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeOfChangeType(ChangeType expectedType, string because = "", params object[] reasonArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, reasonArgs)
+                    .WithExpectation("Expected {context:item change} to be a(n) {0}{reason}, ", changeDescriptions[expectedType])
+                    .ForCondition(!ReferenceEquals(Subject, null))
+                    .FailWith("but found <null>.")
+                    .Then
+                    .Given(() => Subject.Type)
+                    .ForCondition(actualType => actualType == expectedType)
+                    .FailWith("but its actual type was {0:G}.", actualType => actualType);
+
+                return new AndConstraint<ItemChangeAssertions<T>>(this);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeChange(ChangeType expectedType, T expectedItem, string because = "", params object[] reasonArgs)
+            {
+                var expectedChange = changeDescriptions[expectedType];
+
+                Execute.Assertion
+                    .BecauseOf(because, reasonArgs)
+                    .WithExpectation("Expected {context:item change} to be {0} of {1}{reason}, ", expectedChange, expectedItem)
+                    .ForCondition(!ReferenceEquals(Subject, null))
+                    .FailWith("but found <null>.")
+                    .Then
+                    .Given(() => Subject)
+                    .ForCondition(change => change.Type == expectedType)
+                    .FailWith("but found {0} of item {1}.", change => changeDescriptions[change.Type], change => change.Item)
+                    .Then
+                    .Given(change => change.Item)
+                    .ForCondition(item => item.IsSameOrEqualTo(expectedItem))
+                    .FailWith("but found {0} of item {1}.", item => expectedChange, item => item);
+
+                return new AndConstraint<ItemChangeAssertions<T>>(this);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeAddition(string because = "", params object[] reasonArgs)
+            {
+                return BeOfChangeType(ChangeType.Added, because, reasonArgs);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeAdditionOf(T item, string because = "", params object[] reasonArgs)
+            {
+                return BeChange(ChangeType.Added, item, because, reasonArgs);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeRemoval(string because = "", params object[] reasonArgs)
+            {
+                return BeOfChangeType(ChangeType.Removed, because, reasonArgs);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeRemovalOf(T item, string because = "", params object[] reasonArgs)
+            {
+                return BeChange(ChangeType.Removed, item, because, reasonArgs);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeUpdate(string because = "", params object[] reasonArgs)
+            {
+                return BeOfChangeType(ChangeType.Updated, because, reasonArgs);
+            }
+
+            public AndConstraint<ItemChangeAssertions<T>> BeUpdateOf(T item, string because = "", params object[] reasonArgs)
+            {
+                return BeChange(ChangeType.Updated, item, because, reasonArgs);
+            }
+        }
+
+        public class SequenceOfItemChangeAssertions<T>
+        {
+            public IEnumerable<IItemChange<T>> Subject { get; private set; }
+
+            internal SequenceOfItemChangeAssertions(IEnumerable<IItemChange<T>> actualChanges)
+            {
+                this.Subject = actualChanges;
+            }
+
+            public AndConstraint<SequenceOfItemChangeAssertions<T>> Be()
+            {
+                return null;
+            }
+        }
+
+        public static ItemChangeAssertions<T> Should<T>(this IItemChange<T> actualValue)
+        {
+            return new ItemChangeAssertions<T>(actualValue);
+        }
+    }
+}

--- a/Async.Model.TestExtensions/Properties/AssemblyInfo.cs
+++ b/Async.Model.TestExtensions/Properties/AssemblyInfo.cs
@@ -1,14 +1,12 @@
 ﻿using System.Reflection;
-using System.Resources;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyProduct("Async.Model")]
-[assembly: AssemblyTitle("Async.Model")]
-[assembly: AssemblyDescription("Building blocks for asynchronous domain models.")]
-[assembly: NeutralResourcesLanguage("en")]
+[assembly: AssemblyProduct("Async.Model.TestExtensions")]
+[assembly: AssemblyTitle("Async.Model.TestExtensions")]
+[assembly: AssemblyDescription("Test extensions for asynchronous domain models.")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -25,8 +23,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.4")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta3")]
+[assembly: AssemblyFileVersion("1.0.0.4")]

--- a/Async.Model.TestExtensions/packages.config
+++ b/Async.Model.TestExtensions/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="3.4.1" targetFramework="net452" />
+</packages>

--- a/Async.Model.UnitTest/Async.Model.UnitTest.csproj
+++ b/Async.Model.UnitTest/Async.Model.UnitTest.csproj
@@ -36,12 +36,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=3.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.3.4.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=3.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.4.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=3.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.3.4.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.3.4.1\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
@@ -107,14 +107,20 @@
     <Compile Include="Fluent.cs" />
     <Compile Include="FullOuterJoinTest.cs" />
     <Compile Include="GenericContravarianceTest.cs" />
+    <Compile Include="LinqExtensionsTest.cs" />
     <Compile Include="LookupTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SeqTest.cs" />
+    <Compile Include="TestExtensions\FluentAssertionsExtensionsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Async.Model.TestExtensions\Async.Model.TestExtensions.csproj">
+      <Project>{44b10dd1-3734-443f-9d74-eb8beb40ca93}</Project>
+      <Name>Async.Model.TestExtensions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Async.Model\Async.Model.csproj">
       <Project>{222ab3c6-bfdb-40bb-b0ba-9c059b1437e3}</Project>
       <Name>Async.Model</Name>

--- a/Async.Model.UnitTest/Async.Model.UnitTest.csproj
+++ b/Async.Model.UnitTest/Async.Model.UnitTest.csproj
@@ -102,6 +102,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AsyncLoaded\AsyncLoaderBaseTest.cs" />
+    <Compile Include="AsyncLoaded\ThreadSafeAsyncLoaderTest.cs" />
     <Compile Include="AsyncLoaderTest.cs" />
     <Compile Include="Fluent.cs" />
     <Compile Include="FullOuterJoinTest.cs" />

--- a/Async.Model.UnitTest/AsyncLoaded/ThreadSafeAsyncLoaderTest.cs
+++ b/Async.Model.UnitTest/AsyncLoaded/ThreadSafeAsyncLoaderTest.cs
@@ -1,21 +1,81 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Schedulers;
 using Async.Model.AsyncLoaded;
 using Async.Model.Sequence;
+using Async.Model.TestExtensions;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 // Because noone wants to type out this every time...
-using EnumerableOfIntegerChangesAlias = System.Collections.Generic.IEnumerable<Async.Model.IItemChange<int>>;
+using IntChangesAlias = System.Collections.Generic.IEnumerable<Async.Model.IItemChange<int>>;
 
 namespace Async.Model.UnitTest.AsyncLoaded
 {
+    // TODO: Add tests that verify locking once we can use Monitor.IsEntered (when we switch to using lock keyword)
     [TestFixture]
     public class ThreadSafeAsyncLoaderTest
     {
+        #region Replace
         [Test]
-        public void CollectionChangedHandlerInvokedForReplace()
+        public void ReplaceWorksForEmptyLoader()
+        {
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased);
+            loader.Replace(1, 2);  // --- Perform ---
+        }
+
+        [Test]
+        public void ReplaceCanReplaceSingleton()
+        {
+            IEnumerable<int> loadedInts = new[] { 1 };
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, tok => Task.FromResult(loadedInts));
+            loader.LoadAsync();
+
+            loader.Replace(1, 2);  // --- Perform ---
+
+            loader.Should().BeEquivalentTo(new[] { 2 });
+        }
+
+        [Test]
+        public void ReplaceOnSingletonDoesNothingWhenNotMatched()
+        {
+            IEnumerable<int> loadedInts = new[] { 1 };
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, tok => Task.FromResult(loadedInts));
+            loader.LoadAsync();
+
+            loader.Replace(2, 1);  // --- Perform ---
+
+            loader.Should().BeEquivalentTo(new[] { 1 });
+        }
+
+        [Test]
+        public void ReplaceCanReplaceWhenLoaderHasMultipleItems()
+        {
+            IEnumerable<int> loadedInts = new[] { 1, 2, 3 };
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, tok => Task.FromResult(loadedInts));
+            loader.LoadAsync();
+
+            loader.Replace(2, 4);  // --- Perform ---
+
+            loader.Should().BeEquivalentTo(new[] { 1, 4, 3 });
+        }
+
+        [Test]
+        public void ReplaceCanReplaceMultipleItems()
+        {
+            IEnumerable<int> loadedInts = new[] { 1, 1, 1 };
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, tok => Task.FromResult(loadedInts));
+            loader.LoadAsync();
+
+            loader.Replace(1, 2);  // --- Perform ---
+
+            loader.Should().BeEquivalentTo(new[] { 2, 2, 2 });
+        }
+
+        [Test]
+        public void ReplaceNotifiesOfChange()
         {
             IEnumerable<int> loadedInts = new[] { 2 };
             var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, loadDataAsync: tok => Task.FromResult(loadedInts),
@@ -29,8 +89,262 @@ namespace Async.Model.UnitTest.AsyncLoaded
             loader.Replace(2, 1);   // --- Perform ---
 
 
-            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(changes =>
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes =>
                 changes.Should().ContainSingle().Which.ShouldBeEquivalentTo(new ItemChange<int>(ChangeType.Updated, 1))));
         }
+
+        [Test]
+        public void ReplaceNotifiesOfEveryChangeMade()
+        {
+            IEnumerable<int> loadedInts = new[] { 2, 2, 2, 2 };
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Replace(2, 1);   // --- Perform ---
+
+
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes =>
+                changes.Should().BeEquivalentTo(Enumerable.Repeat(new ItemChange<int>(ChangeType.Updated, 1), 4))));
+        }
+
+        [Test]
+        public void ReplaceDoesNotNotifyIfLoaderIsEmpty()
+        {
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, eventScheduler: new CurrentThreadTaskScheduler());
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Replace(1, 2);  // --- Perform ---
+
+
+            listener.DidNotReceive().Invoke(loader, Arg.Any<IntChangesAlias>());
+        }
+
+        [Test]
+        public void ReplaceDoesNotNotifyIfItemNotFound()
+        {
+            IEnumerable<int> initialValues = new[] { 1, 2 };
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(initialValues),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();  // load initial values
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Replace(3, 1);  // --- Perform ---
+
+
+            listener.DidNotReceive().Invoke(loader, Arg.Any<IntChangesAlias>());
+        }
+        #endregion Replace
+
+        #region ReplaceAll
+        [Test]
+        public void ReplaceAllDelegatesToUnderlyingSeq()
+        {
+            var items = new[] { 1, 2, 3, 4 };
+            var seq = Substitute.For<ISeq<int>>();
+            var loader = new ThreadSafeAsyncLoader<int>(enumerable => seq);
+
+            loader.ReplaceAll(items);  // --- Perform ---
+
+            seq.Received().ReplaceAll(items);
+        }
+
+        [Test]
+        public void ReplaceAllNotifiesOfChangesMade()
+        {
+            IEnumerable<int> loadedInts = new int[] { 1, 2, 3, 4 };
+            var replacements = new int[] { 5, 6 };
+
+            var expectedChanges = loadedInts.Select(i => new ItemChange<int>(ChangeType.Removed, i))
+                .Concat(replacements.Select(i => new ItemChange<int>(ChangeType.Added, i)));
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Should().Equal(loadedInts);  // sanity check
+            loader.ReplaceAll(replacements);  // --- Perform ---
+            loader.Should().Equal(replacements);  // sanity check
+
+
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(
+                changes => changes.Should().BeEquivalentTo(expectedChanges)));
+        }
+
+        /// <summary>
+        /// This test illustrates an important limitation of ThreadSafeAsyncLoader: since it cannot
+        /// know in general whether two objects that test equal are identical or just similar, it
+        /// makes the conservative choice of always assuming that an item present in both the old
+        /// and new sequences have been updated. This should not cause correctness problems, but
+        /// could potentially cause performance issues.
+        /// </summary>
+        [Test]
+        [Category("Limitations")]
+        public void ReplaceAllIssuesUpdateNotificationsForUnchangedItems()
+        {
+            IEnumerable<int> loadedInts = new int[] { 1 };
+            var replacements = new int[] { 1, 2 };
+
+            var expectedChanges = new IItemChange<int>[]
+            {
+                new ItemChange<int>(ChangeType.Updated, 1),
+                new ItemChange<int>(ChangeType.Added, 2)
+            };
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.ReplaceAll(replacements);  // --- Perform ---
+
+
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(
+                changes => changes.Should().BeEquivalentTo(expectedChanges)));
+        }
+
+        /// <summary>
+        /// This test shows an important limitation of ReplaceAll: it will not accept the presence
+        /// of duplicates in the <see cref="ThreadSafeAsyncLoader{TItem}"/> at the time of calling
+        /// the method.
+        /// </summary>
+        [Test]
+        [Category("Limitations")]
+        public void ReplaceAllDoesNotAllowDuplicatesInLoader()
+        {
+            IEnumerable<int> loadedInts = new[] { 1, 1, 1 };
+            var replacements = new[] { 2, 3 };
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();
+
+
+            // --- Perform ---
+            Action callingReplaceAll = () => loader.ReplaceAll(replacements);
+            callingReplaceAll.ShouldThrow<ArgumentException>("because duplicates are not allowed").WithMessage("*duplicates*");
+        }
+
+        /// <summary>
+        /// This test shows off an important limitation of ReplaceAll: it will not accept the
+        /// presence of duplicates in <paramref name="newItems"/>.
+        /// </summary>
+        [Test]
+        [Category("Limitations")]
+        public void ReplaceAllDoesNotAllowDuplicatesInNewItems()
+        {
+            IEnumerable<int> loadedInts = new[] { 1, 2, 3 };
+            var replacements = new[] { 2, 2 };
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();
+
+
+            // --- Perform ---
+            Action callingReplaceAll = () => loader.ReplaceAll(replacements);
+            callingReplaceAll.ShouldThrow<ArgumentException>("because duplicates are not allowed").WithMessage("*duplicates*");
+        }
+        #endregion ReplaceAll
+
+        #region Clear
+        [Test]
+        public void ClearDelegatesToUnderlyingSeq()
+        {
+            var seq = Substitute.For<ISeq<int>>();
+            var loader = new ThreadSafeAsyncLoader<int>(enumerable => seq);
+
+            loader.Clear();  // --- Perform ---
+
+            seq.Received().Clear();
+        }
+
+        [Test]
+        public void ClearNotifiesOfChangeForSingletonSeq()
+        {
+            IEnumerable<int> initialValues = new[] { 1 };
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(initialValues),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();  // load initial values
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Clear();  // --- Perform ---
+
+
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes => changes
+                .Should().ContainSingle("because loader contained single item before Clear")
+                .Which.Should().BeRemovalOf(1, "because loader contained the value 1 before Clear")));
+        }
+
+        [Test]
+        public void ClearNotifiesOfChangesMade()
+        {
+            IEnumerable<int> initialValues = new[] { 1, 2, 3 };
+            var expectedChanges = initialValues.Select(i => new ItemChange<int>(ChangeType.Removed, i));
+
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(initialValues),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();  // load initial values
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Clear();  // --- Perform ---
+
+
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(
+                changes => changes.Should().BeEquivalentTo(expectedChanges)));
+        }
+
+        [Test]
+        public void ClearDoesNotNotifyIfNoChangesWereMade()
+        {
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, eventScheduler: new CurrentThreadTaskScheduler());
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Clear();  // --- Perform ---
+
+
+            listener.DidNotReceive().Invoke(loader, Arg.Any<IntChangesAlias>());
+        }
+        #endregion Clear
     }
 }

--- a/Async.Model.UnitTest/AsyncLoaded/ThreadSafeAsyncLoaderTest.cs
+++ b/Async.Model.UnitTest/AsyncLoaded/ThreadSafeAsyncLoaderTest.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Schedulers;
+using Async.Model.AsyncLoaded;
+using Async.Model.Sequence;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+// Because noone wants to type out this every time...
+using EnumerableOfIntegerChangesAlias = System.Collections.Generic.IEnumerable<Async.Model.IItemChange<int>>;
+
+namespace Async.Model.UnitTest.AsyncLoaded
+{
+    [TestFixture]
+    public class ThreadSafeAsyncLoaderTest
+    {
+        [Test]
+        public void CollectionChangedHandlerInvokedForReplace()
+        {
+            IEnumerable<int> loadedInts = new[] { 2 };
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.Replace(2, 1);   // --- Perform ---
+
+
+            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(changes =>
+                changes.Should().ContainSingle().Which.ShouldBeEquivalentTo(new ItemChange<int>(ChangeType.Updated, 1))));
+        }
+    }
+}

--- a/Async.Model.UnitTest/AsyncLoaderTest.cs
+++ b/Async.Model.UnitTest/AsyncLoaderTest.cs
@@ -1,18 +1,14 @@
-﻿using FluentAssertions;
-using Async.Model;
-using Async.Model.Sequence;
-using NSubstitute;
-using NUnit.Framework;
-using System;
-using System.Collections.Concurrent;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Schedulers;
-using FluentAssertions.Formatting;
-using EnumerableOfIntegerChangesAlias = System.Collections.Generic.IEnumerable<Async.Model.IItemChange<int>>;
+using Async.Model.Sequence;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using IntChangesAlias = System.Collections.Generic.IEnumerable<Async.Model.IItemChange<int>>;
 
 namespace Async.Model.UnitTest
 {
@@ -31,9 +27,7 @@ namespace Async.Model.UnitTest
         {
             var loader = new AsyncLoader<string>(
                 seqFactory: Seq.ListBased,
-                loadDataAsync: token => Task.FromResult((IEnumerable<string>)new string[] { }),
-                fetchUpdatesAsync: null,
-                rootCancellationToken: CancellationToken.None);
+                loadDataAsync: token => Task.FromResult(Enumerable.Empty<string>()));
 
             loader.LoadAsync();
 
@@ -48,9 +42,7 @@ namespace Async.Model.UnitTest
 
             var loader = new AsyncLoader<int>(
                 seqFactory: Seq.ListBased,
-                loadDataAsync: t => Task.FromResult(loadedItems.AsEnumerable()),
-                fetchUpdatesAsync: null,
-                rootCancellationToken: CancellationToken.None);
+                loadDataAsync: t => Task.FromResult(loadedItems.AsEnumerable()));
             IEnumerable<int> values = loader;
 
 
@@ -72,11 +64,36 @@ namespace Async.Model.UnitTest
             var loader = new AsyncLoader<int>(seqFactory: Seq.ListBased, loadDataAsync: loadFunc);
 
             loader.LoadAsync();  // initial load
-            Assert.That(loader, Is.EqualTo(originalItems));  // sanity check
+            loader.Should().BeEquivalentTo(originalItems);  // sanity check
 
 
             loader.LoadAsync();  // --- Perform ---
-            Assert.That(loader, Is.EqualTo(loadedItems));
+            loader.Should().BeEquivalentTo(loadedItems);
+        }
+
+        /// <summary>
+        /// This is an important use-case for the send queue: while loading any old contents of the
+        /// queue, the user should be allowed to compose and queue a new teamstring for sending.
+        /// This means that LoadAsync must keep items added during the load.
+        /// </summary>
+        [Test]
+        public async Task LoadAsyncPreservesItemsAddedDuringLoad()
+        {
+            IEnumerable<int> itemsToLoad = new[] { 2, 3, 4 };
+            var loadTask = new TaskCompletionSource<IEnumerable<int>>();
+            var loader = new AsyncLoader<int>(seqFactory: Seq.ListBased, loadDataAsync: tok => loadTask.Task);
+
+
+            // --- Perform ---
+            var loadComplete = loader.LoadAsync();  // Will get stuck, waiting for loadTask to complete
+            loader.Conj(1);
+
+
+            loader.Should().BeEquivalentTo(new[] { 1 });  // sanity check
+            loadTask.SetResult(itemsToLoad);  // complete loading
+            await loadComplete;  // wait for LoadAsync to finish
+
+            loader.Should().BeEquivalentTo(new[] { 1, 2, 3, 4 });
         }
 
         /// <summary>
@@ -88,11 +105,7 @@ namespace Async.Model.UnitTest
         [Test]
         public void CanAddCollectionChangeHandlersOfDifferentTypes()
         {
-            var loader = new AsyncLoader<Item>(
-                seqFactory: Seq.ListBased,
-                loadDataAsync: null,
-                fetchUpdatesAsync: null,
-                rootCancellationToken: CancellationToken.None);
+            var loader = new AsyncLoader<Item>(seqFactory: Seq.ListBased);
 
             // Simulate an external consumer of this collection
             IAsyncCollection<IItem> externalView = loader;
@@ -110,8 +123,6 @@ namespace Async.Model.UnitTest
             var loader = new AsyncLoader<int>(
                 seqFactory: Seq.ListBased,
                 loadDataAsync: t => Task.FromResult(loadedItems.AsEnumerable()),
-                fetchUpdatesAsync: null,
-                rootCancellationToken: CancellationToken.None,
                 eventScheduler: new CurrentThreadTaskScheduler());
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
@@ -120,9 +131,9 @@ namespace Async.Model.UnitTest
 
             loader.LoadAsync();  // --- Perform ---
 
-
+            
             var expectedChanges = loadedItems.Select(i => new ItemChange<int>(ChangeType.Added, i));
-            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(coll =>
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(coll =>
                 coll.Should().BeEquivalentTo(expectedChanges)));
         }
 
@@ -134,8 +145,6 @@ namespace Async.Model.UnitTest
             var loader = new AsyncLoader<Item>(
                 seqFactory: Seq.ListBased,
                 loadDataAsync: t => Task.FromResult(loadedItems),
-                fetchUpdatesAsync: null,
-                rootCancellationToken: CancellationToken.None,
                 eventScheduler: new CurrentThreadTaskScheduler());
 
             // Simulate an external consumer of this collection
@@ -160,6 +169,51 @@ namespace Async.Model.UnitTest
 
         void DummyChangesListener(object sender, IEnumerable<IItemChange<IItem>> changes) { }
         void DummyRootListener(object sender, IEnumerable<IItemChange<IRoot>> changes) { }
+
+        [Test]
+        public void LoadAsyncNotifiesOfClearedItems()
+        {
+            IEnumerable<int> initialItems = new[] { 1, 2, 3 };
+            IEnumerable<int> loadedItems = new[] { 4, 5, 6 };
+
+            var actualChanges = new List<IItemChange<int>>();
+            IntChangesAlias expectedChanges = initialItems
+                .Select(i => new ItemChange<int>(ChangeType.Removed, i))
+                .Concat(loadedItems.Select(i => new ItemChange<int>(ChangeType.Added, i)));
+
+            var loadFunc = Substitute.For<Func<CancellationToken, Task<IEnumerable<int>>>>();
+            loadFunc.Invoke(Arg.Any<CancellationToken>()).Returns(Task.FromResult(initialItems), Task.FromResult(loadedItems));
+
+            var loader = new AsyncLoader<int>(Seq.ListBased, loadDataAsync: loadFunc, eventScheduler: new CurrentThreadTaskScheduler());
+            loader.LoadAsync();  // initial load
+            loader.CollectionChanged += (s, e) => actualChanges.AddRange(e);  // add all emitted changes to a list
+
+
+            loader.LoadAsync();  // --- Perform ---
+
+
+            actualChanges.Should().BeEquivalentTo(expectedChanges);
+        }
+
+        [Test]
+        public void LoadAsyncDoesNotNotifyOfClearIfEmptyBeforeCall()
+        {
+            IEnumerable<int> loadedItems = new[] { 1 };
+
+            var loader = new AsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedItems),
+                eventScheduler: new CurrentThreadTaskScheduler());
+
+            var listener = Substitute.For<CollectionChangedHandler<int>>();
+            loader.CollectionChanged += listener;
+
+
+            loader.LoadAsync();  // --- Perform ---
+
+
+            listener.Received(1).Invoke(loader, Arg.Any<IntChangesAlias>());
+        }
 
         [Test]
         public void CanEnumerateWithoutLoadOrUpdate()
@@ -187,7 +241,7 @@ namespace Async.Model.UnitTest
             loader.Conj(1);  // --- Perform ---
 
             
-            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(changes =>
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes =>
                 changes.Should().ContainSingle().Which.ShouldBeEquivalentTo(new ItemChange<int>(ChangeType.Added, 1))));
         }
 
@@ -202,7 +256,7 @@ namespace Async.Model.UnitTest
             await loader.ConjAsync(1, CancellationToken.None);  // --- Perform ---
 
 
-            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(changes =>
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes =>
                 changes.Should().ContainSingle().Which.ShouldBeEquivalentTo(new ItemChange<int>(ChangeType.Added, 1))));
         }
 
@@ -221,7 +275,7 @@ namespace Async.Model.UnitTest
             loader.Take();  // --- Perform ---
 
 
-            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(changes =>
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes =>
                 changes.Should().ContainSingle().Which.ShouldBeEquivalentTo(new ItemChange<int>(ChangeType.Removed, 42))));
         }
 
@@ -231,7 +285,7 @@ namespace Async.Model.UnitTest
             IEnumerable<int> loadedInts = new[] { 35 };
             var loader = new AsyncLoader<int>(Seq.ListBased, loadDataAsync: tok => Task.FromResult(loadedInts),
                 eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+            await loader.LoadAsync();
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
@@ -240,11 +294,12 @@ namespace Async.Model.UnitTest
             await loader.TakeAsync(CancellationToken.None);  // --- Perform ---
 
 
-            listener.Received().Invoke(loader, Fluent.Match<EnumerableOfIntegerChangesAlias>(changes =>
+            listener.Received().Invoke(loader, Fluent.Match<IntChangesAlias>(changes =>
                 changes.Should().ContainSingle().Which.ShouldBeEquivalentTo(new ItemChange<int>(ChangeType.Removed, 35))));
         }
 
         [Test]
+        [Category("Limitations")]
         public void AsyncLoaderDoesNotSupportReplace()
         {
             var loader = new AsyncLoader<int>(Seq.ListBased);
@@ -253,6 +308,7 @@ namespace Async.Model.UnitTest
         }
 
         [Test]
+        [Category("Limitations")]
         public void AsyncLoaderDoesNotSupportReplaceAll()
         {
             var loader = new AsyncLoader<int>(Seq.ListBased);
@@ -261,6 +317,7 @@ namespace Async.Model.UnitTest
         }
 
         [Test]
+        [Category("Limitations")]
         public void AsyncLoaderDoesNotSupportClear()
         {
             var loader = new AsyncLoader<int>(Seq.ListBased);

--- a/Async.Model.UnitTest/LinqExtensionsTest.cs
+++ b/Async.Model.UnitTest/LinqExtensionsTest.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Async.Model.UnitTest
+{
+    [TestFixture]
+    public class LinqExtensionsTest
+    {
+        [Test]
+        public void ChangesFromReturnsNoChangesForEmptySequences()
+        {
+            var changes = Enumerable.Empty<int>()
+                .ChangesFrom(Enumerable.Empty<int>());  // --- Perform ---
+
+            changes.Should().BeEmpty("because there can be no changes between two empty sequences");
+        }
+
+        [Test]
+        public void ChangesFromReturnsNoChangesForSingletonSequenceComparedToItself()
+        {
+            var sequence = new int[] { 1 };
+            var changes = sequence.ChangesFrom(sequence);  // --- Perform ---
+
+            changes.Should().BeEmpty("because there can be no changes between a sequence and itself");
+        }
+
+        [Test]
+        public void ChangesFromReturnsNoChangesForSequenceComparedToItself()
+        {
+            var sequence = new int[] { 1, 2, 3, 4 };
+            var changes = sequence.ChangesFrom(sequence);  // --- Perform ---
+
+            changes.Should().BeEmpty("because there can be no changes between a sequence and itself");
+        }
+
+        [Test]
+        public void ChangesFromReturnsCorrectChangesForDifferentSingletonSequences()
+        {
+            // Precondition: ItemChange implements Equals in natural way
+            var change1 = new ItemChange<int>(ChangeType.Added, 1);
+            var change2 = new ItemChange<int>(ChangeType.Added, 1);
+            change1.Should().Be(change2);
+
+            var oldSeq = new int[] { 1 };
+            var newSeq = new int[] { 2 };
+            IEnumerable<IItemChange<int>> expectedChanges = new[]
+            {
+                new ItemChange<int>(ChangeType.Removed, 1),
+                new ItemChange<int>(ChangeType.Added, 2)
+            };
+
+            var changes = newSeq.ChangesFrom(oldSeq);  // --- Perform ---
+
+            changes.Should().BeEquivalentTo(expectedChanges);
+        }
+
+        [Test]
+        public void ChangesFromReturnsExpectedChangesForDifferentSequences()
+        {
+            var oldSeq = new int[] { 1, 2, 3, 4 };
+            var newSeq = new int[] { 3, 4, 5, 6 };
+            IEnumerable<IItemChange<int>> expectedChanges = new[]
+            {
+                new ItemChange<int>(ChangeType.Removed, 1),
+                new ItemChange<int>(ChangeType.Removed, 2),
+                new ItemChange<int>(ChangeType.Added, 5),
+                new ItemChange<int>(ChangeType.Added, 6)
+            };
+
+            var actualChanges = newSeq.ChangesFrom(oldSeq);  // --- Perform ---
+            actualChanges.Should().BeEquivalentTo(expectedChanges);
+        }
+
+        [Test]
+        public void ChangesFromRejectsNullOldItems()
+        {
+            var newSeq = new int[] { 1 };
+
+            // --- Perform ---
+            Action callingChangesFrom = () => newSeq.ChangesFrom(null);
+            callingChangesFrom.ShouldThrow<ArgumentNullException>().WithMessage("*oldItems*");
+        }
+
+        [Test]
+        public void ChangesFromRejectsNullNewItems()
+        {
+            var oldSeq = new int[] { 1 };
+            IEnumerable<int> newSeq = null;
+
+            // --- Perform ---
+            Action callingChangesFrom = () => newSeq.ChangesFrom(oldSeq);
+            callingChangesFrom.ShouldThrow<ArgumentNullException>().WithMessage("*newItems*");
+        }
+
+        [Test]
+        [Category("Limitations")]
+        public void ChangesFromDoesNotAllowDuplicatesInOldItems()
+        {
+            var oldSeq = new int[] { 1, 2, 1 };
+            var newSeq = new int[] { 1, 2, 3 };
+
+            // --- Perform ---
+            Func<IEnumerable> changesIterator = () => newSeq.ChangesFrom(oldSeq);
+            // We need to force enumeration, since ChangesFrom uses deferred execution and duplicates are discovered lazily
+            changesIterator.Enumerating()
+                .ShouldThrow<ArgumentException>("because duplicates are forbidden")
+                .WithMessage("*oldItems*", "because error message should name faulty parameter");
+        }
+
+        [Test]
+        [Category("Limitations")]
+        public void ChangesFromDoesNotAllowDuplicatesInNewItems()
+        {
+            var oldSeq = new int[] { 1, 2, 3 };
+            var newSeq = new int[] { 1, 1 };
+
+            // --- Perform ---
+            Func<IEnumerable> changesIterator = () => newSeq.ChangesFrom(oldSeq);
+            changesIterator.Enumerating()
+                .ShouldThrow<ArgumentException>("because duplicates are forbidden")
+                .WithMessage("*newItems*", "because error message should name faulty parameter");
+        }
+    }
+}

--- a/Async.Model.UnitTest/Properties/AssemblyInfo.cs
+++ b/Async.Model.UnitTest/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.4")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta3")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta4")]

--- a/Async.Model.UnitTest/SeqTest.cs
+++ b/Async.Model.UnitTest/SeqTest.cs
@@ -13,6 +13,7 @@ namespace Async.Model.UnitTest
     [TestFixture]
     public class SeqTest
     {
+        #region ListBasedSeq
         [Test]
         public void ListBasedSeqCreatesSeqOfGivenItems()
         {
@@ -20,6 +21,7 @@ namespace Async.Model.UnitTest
             Assert.That(seq, Is.EqualTo(new[] { 1, 2, 3 }));
         }
 
+        #region Conj
         [Test]
         public void ConjOnListBasedSeqAddsToEnd()
         {
@@ -35,7 +37,9 @@ namespace Async.Model.UnitTest
             seq.Conj(1);
             Assert.That(seq, Is.EqualTo(new[] { 1 }));
         }
+        #endregion Conj
 
+        #region Take
         [Test]
         public void TakeOnListBasedSeqRemovesFromStart()
         {
@@ -53,7 +57,57 @@ namespace Async.Model.UnitTest
             var seq = Seq.ListBased(new int[0]);
             seq.Take();
         }
+        #endregion Take
 
+        #region Replace
+        [Test]
+        public void ReplaceOnEmptyListBasedSeqDoesNothing()
+        {
+            var emptySeq = Seq.ListBased(new int[0]);
+            emptySeq.Replace(1, 2);
+
+            Assert.That(emptySeq, Is.Empty);
+        }
+
+        [Test]
+        public void ReplaceOnListBasedSeqWithSingleItemReplacesItemWhenMatched()
+        {
+            var singleton = Seq.ListBased(new[] { 1 });
+            singleton.Replace(1, 2);
+
+            Assert.That(singleton, Is.EqualTo(new[] { 2 }));
+        }
+
+        [Test]
+        public void ReplaceOnListBasedSeqWithSingleDoesNothingWhenNotMatched()
+        {
+            var singleton = Seq.ListBased(new[] { 1 });
+            singleton.Replace(2, 1);
+
+            Assert.That(singleton, Is.EqualTo(new[] { 1 }));
+        }
+
+        [Test]
+        public void ReplaceOnListBasedSeqReplacesAllOccurrences()
+        {
+            var duplicates = Seq.ListBased(new[] { 1, 2, 3, 2, 4, 2 });
+            duplicates.Replace(2, 3);
+
+            Assert.That(duplicates, Is.EqualTo(new[] { 1, 3, 3, 3, 4, 3 }));
+        }
+
+        [Test]
+        public void ReplaceOnListBasedSeqWithSameValueDoesNothing()
+        {
+            var repeated = Seq.ListBased(new[] { 1, 1, 1 });
+            repeated.Replace(1, 1);
+
+            Assert.That(repeated, Is.EqualTo(new[] { 1, 1, 1 }));
+        }
+        #endregion Replace
+        #endregion ListBasedSeq
+
+        #region QueueBasedSeq
         [Test]
         public void QueueBasedSeqCreatesSeqOfGivenItems()
         {
@@ -61,6 +115,7 @@ namespace Async.Model.UnitTest
             Assert.That(seq, Is.EqualTo(new[] { 1, 2, 3 }));
         }
 
+        #region Conj
         [Test]
         public void ConjOnQueueBasedSeqEnqueuesToEnd()
         {
@@ -76,7 +131,9 @@ namespace Async.Model.UnitTest
             seq.Conj(1);
             Assert.That(seq, Is.EqualTo(new[] { 1 }));
         }
+        #endregion Conj
 
+        #region Take
         [Test]
         public void TakeOnQueueBasedSeqDequeuesFromStart()
         {
@@ -94,7 +151,57 @@ namespace Async.Model.UnitTest
             var seq = Seq.QueueBased(new int[0]);
             seq.Take();
         }
+        #endregion Take
 
+        #region Replace
+        [Test]
+        public void ReplaceOnEmptyQueueBasedSeqDoesNothing()
+        {
+            var emptySeq = Seq.QueueBased(new int[0]);
+            emptySeq.Replace(1, 2);
+
+            Assert.That(emptySeq, Is.Empty);
+        }
+
+        [Test]
+        public void ReplaceOnQueueBasedSeqWithSingleItemReplacesItemWhenMatched()
+        {
+            var singleton = Seq.QueueBased(new[] { 1 });
+            singleton.Replace(1, 2);
+
+            Assert.That(singleton, Is.EqualTo(new[] { 2 }));
+        }
+
+        [Test]
+        public void ReplaceOnQueueBasedSeqWithSingleDoesNothingWhenNotMatched()
+        {
+            var singleton = Seq.QueueBased(new[] { 1 });
+            singleton.Replace(2, 1);
+
+            Assert.That(singleton, Is.EqualTo(new[] { 1 }));
+        }
+
+        [Test]
+        public void ReplaceOnQueueBasedSeqReplacesAllOccurrences()
+        {
+            var duplicates = Seq.QueueBased(new[] { 1, 2, 3, 2, 4, 2 });
+            duplicates.Replace(2, 3);
+
+            Assert.That(duplicates, Is.EqualTo(new[] { 1, 3, 3, 3, 4, 3 }));
+        }
+
+        [Test]
+        public void ReplaceOnQueueBasedSeqWithSameValueDoesNothing()
+        {
+            var repeated = Seq.QueueBased(new[] { 1, 1, 1 });
+            repeated.Replace(1, 1);
+
+            Assert.That(repeated, Is.EqualTo(new[] { 1, 1, 1 }));
+        }
+        #endregion Replace
+        #endregion QueueBasedSeq
+
+        #region AsAsync
         [Test]
         public void AsAsyncYieldsSeqWithSameItems()
         {
@@ -129,6 +236,17 @@ namespace Async.Model.UnitTest
         }
 
         [Test]
+        public void AsAsyncReplaceDelegatesToInnerSeq()
+        {
+            var innerSeq = Substitute.For<ISeq<int>>();
+
+            var asyncSeq = innerSeq.AsAsync();
+            asyncSeq.Replace(1, 2);
+
+            innerSeq.Received(1).Replace(1, 2);
+        }
+
+        [Test]
         public void AsAsyncConjAsyncDelegatesToInnerSeq()
         {
             var innerSeq = Substitute.For<ISeq<int>>();
@@ -155,7 +273,9 @@ namespace Async.Model.UnitTest
 
             innerSeq.Received(1).Take();
         }
+        #endregion AsAsync
 
+        #region SeqOverImmutableCollection
         // TODO: Should we delete the following tests and supporting class, since seqs based on immutable collections
         // are now a lot less useful, given that you can no longer create an immutable seq?
         [Test]
@@ -241,5 +361,6 @@ namespace Async.Model.UnitTest
                 return innerList.GetEnumerator();
             }
         }
+        #endregion SeqOverImmutableCollection
     }
 }

--- a/Async.Model.UnitTest/TestExtensions/FluentAssertionsExtensionsTest.cs
+++ b/Async.Model.UnitTest/TestExtensions/FluentAssertionsExtensionsTest.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Async.Model.TestExtensions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Async.Model.UnitTest.TestExtensions
+{
+    [TestFixture]
+    public class FluentAssertionsExtensionsTest
+    {
+        #region ItemChangeAssertions
+        [Test]
+        public void CanAssertAddition()
+        {
+            var change = new ItemChange<int>(ChangeType.Added, 4);
+            change.Should().BeOfChangeType(ChangeType.Added);
+            change.Should().BeAddition();
+        }
+
+        [Test]
+        public void CanAssertRemoval()
+        {
+            var change = new ItemChange<int>(ChangeType.Removed, 2);
+            change.Should().BeOfChangeType(ChangeType.Removed);
+            change.Should().BeRemoval();
+        }
+
+        [Test]
+        public void CanAssertUpdate()
+        {
+            var change = new ItemChange<int>(ChangeType.Updated, 1);
+            change.Should().BeOfChangeType(ChangeType.Updated);
+            change.Should().BeUpdate();
+        }
+
+        [Test]
+        public void AssertOfChangeTypeHandlesNullSubject()
+        {
+            IItemChange<int> change = null;
+            Action assert = () => change.Should().BeOfChangeType(ChangeType.Added);
+            assert.ShouldThrow<Exception>().WithMessage("Expected item change to be*addition*but found <null>*");
+        }
+
+        [Test]
+        public void AssertOfChangeTypeDoesNotAcceptDifferentChange()
+        {
+            var change = new ItemChange<int>(ChangeType.Removed, 1);
+
+            // Expect addition, but actual is removal
+            Action assert = () => change.Should().BeOfChangeType(ChangeType.Added);
+            assert.ShouldThrow<Exception>().WithMessage("Expected item change to be*addition*but*was Removed*");
+
+            // Expect update, but actual is removal
+            assert = () => change.Should().BeOfChangeType(ChangeType.Updated);
+            assert.ShouldThrow<Exception>().WithMessage("Expected item change to be*update*but*was Removed*");
+        }
+
+        [Test]
+        public void FailedAssertOfChangeTypeAppendsReasonAsExpected()
+        {
+            var change = new ItemChange<int>(ChangeType.Removed, 333);
+
+            Action assert = () => change.Should().BeOfChangeType(ChangeType.Added, "because I say so and also because {0} <> {1}", 1, 2);
+            assert.ShouldThrow<Exception>().WithMessage("*to be*addition*because I say so and also because 1 <> 2, but*");
+        }
+
+        [Test]
+        public void CanAssertAdditionOfItem()
+        {
+            var change = new ItemChange<int>(ChangeType.Added, 5);
+            change.Should().BeChange(ChangeType.Added, 5);
+            change.Should().BeAdditionOf(5);
+        }
+
+        [Test]
+        public void CanAssertRemovalOfItem()
+        {
+            var change = new ItemChange<int>(ChangeType.Removed, 1);
+            change.Should().BeChange(ChangeType.Removed, 1);
+            change.Should().BeRemovalOf(1);
+        }
+
+        [Test]
+        public void CanAssertUpdateOfItem()
+        {
+            var change = new ItemChange<int>(ChangeType.Updated, 100);
+            change.Should().BeChange(ChangeType.Updated, 100);
+            change.Should().BeUpdateOf(100);
+        }
+
+        [Test]
+        public void AssertOfChangeHandlesNullSubject()
+        {
+            IItemChange<int> change = null;
+            Action assert = () => change.Should().BeChange(ChangeType.Added, 1);
+            assert.ShouldThrow<Exception>().WithMessage("Expected item change to be*addition*of 1*but found <null>*");
+        }
+
+        [Test]
+        public void AssertOfChangeDoesNotAcceptDifferentType()
+        {
+            var change = new ItemChange<int>(ChangeType.Unchanged, 10);
+            Action assert = () => change.Should().BeChange(ChangeType.Added, 10);
+            assert.ShouldThrow<Exception>().WithMessage("Expected item change to be*addition*of 10*but found *unchanging*of*10*");
+        }
+
+        [Test]
+        public void AssertOfChangeDoesNotAcceptDifferentItem()
+        {
+            var change = new ItemChange<int>(ChangeType.Added, 1);
+            Action assert = () => change.Should().BeChange(ChangeType.Added, 2);
+            assert.ShouldThrow<Exception>().WithMessage("Expected item change to be*addition*of 2*but found *addition*of*1*");
+        }
+
+        [Test]
+        public void FailedAssertOfChangeAppendsReasonAsExpected()
+        {
+            var change = new ItemChange<int>(ChangeType.Updated, 2);
+            Action assert = () => change.Should().BeChange(ChangeType.Removed, 1, "because {0} should be removed", 1);
+            assert.ShouldThrow<Exception>().WithMessage("*removal*of 1 because 1 should be removed*");
+        }
+        #endregion ItemChangeAssertions
+    }
+}

--- a/Async.Model.UnitTest/packages.config
+++ b/Async.Model.UnitTest/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="3.4.0" targetFramework="net45" />
-  <package id="MSFT.ParallelExtensionsExtras" version="1.2.0" targetFramework="net45" userInstalled="true" />
+  <package id="FluentAssertions" version="3.4.1" targetFramework="net45" />
+  <package id="MSFT.ParallelExtensionsExtras" version="1.2.0" targetFramework="net45" />
   <package id="Nito.AsyncEx" version="3.0.1-zhivepeople" targetFramework="net45" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" userInstalled="true" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" userInstalled="true" />
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
 </packages>

--- a/Async.Model.sln
+++ b/Async.Model.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Async.Model", "Async.Model\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Async.Model.UnitTest", "Async.Model.UnitTest\Async.Model.UnitTest.csproj", "{F2FDCF26-E207-4AD6-8BC9-B7DB442EFF1F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Async.Model.TestExtensions", "Async.Model.TestExtensions\Async.Model.TestExtensions.csproj", "{44B10DD1-3734-443F-9D74-EB8BEB40CA93}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{F2FDCF26-E207-4AD6-8BC9-B7DB442EFF1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2FDCF26-E207-4AD6-8BC9-B7DB442EFF1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2FDCF26-E207-4AD6-8BC9-B7DB442EFF1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44B10DD1-3734-443F-9D74-EB8BEB40CA93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44B10DD1-3734-443F-9D74-EB8BEB40CA93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44B10DD1-3734-443F-9D74-EB8BEB40CA93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44B10DD1-3734-443F-9D74-EB8BEB40CA93}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Async.Model/AsyncLoaded/AsyncLoaderBase.cs
+++ b/Async.Model/AsyncLoaded/AsyncLoaderBase.cs
@@ -14,6 +14,7 @@ namespace Async.Model.AsyncLoaded
         /// <summary>The root cancellation token this loader was initialized with. Allows for grouped cancellation.</summary>
         protected readonly CancellationToken rootCancellationToken;
 
+        // TODO: make mutex a plain object and switch to use lock keyword: we never use the async feature anyway and we want reentrancy
         /// <summary>A lock that can be taken both synchronously and asynchronously. This lock should always be used when accessing mutable fields.</summary>
         /// <remarks>An AsyncLock is NOT reentrant, so subclasses must be careful to only take it when it is known to not already be held.</remarks>
         protected readonly AsyncLock mutex = new AsyncLock();
@@ -191,8 +192,7 @@ namespace Async.Model.AsyncLoaded
             // Perform notification on event scheduler
             Task.Factory.StartNew(() =>
             {
-                if (operationCompletedHandler != null)
-                    operationCompletedHandler(this, result);
+                operationCompletedHandler(this, result);
             }, CancellationToken.None, TaskCreationOptions.None, eventScheduler);
         }
 

--- a/Async.Model/AsyncLoaded/IAsyncCollectionLoader.cs
+++ b/Async.Model/AsyncLoaded/IAsyncCollectionLoader.cs
@@ -1,10 +1,11 @@
-﻿using Async.Model.Sequence;
+﻿using System.Threading.Tasks;
+using Async.Model.Sequence;
 
 namespace Async.Model.AsyncLoaded
 {
     public interface IAsyncCollectionLoader<T> : IAsyncCollection<T>, IAsyncSeq<T>
     {
-        void LoadAsync();
-        void UpdateAsync();
+        Task LoadAsync();
+        Task UpdateAsync();
     }
 }

--- a/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
+++ b/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
@@ -1,16 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Async.Model;
 using Async.Model.Sequence;
 
 namespace Async.Model.AsyncLoaded
 {
     public sealed class ThreadSafeAsyncLoader<TItem> : AsyncLoader<TItem>
     {
+
+        /// <summary>
+        /// An update comparer that deems any item updated by always returning false. Necessary
+        /// because we cannot in general know if two items that test equal are in fact identical.
+        /// By doing this we choose correctness over performance: we may notify about updates where
+        /// none occurred, but at least we will never miss an update.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        class ConservativeUpdateComparer<T> : EqualityComparer<T>
+        {
+            public override bool Equals(T x, T y)
+            {
+                return false;
+            }
+
+            public override int GetHashCode(T obj)
+            {
+                return obj.GetHashCode();
+            }
+        }
+
+        private static readonly ConservativeUpdateComparer<TItem> conservativeUpdateComparer = new ConservativeUpdateComparer<TItem>();
+
         public ThreadSafeAsyncLoader(
             Func<IEnumerable<TItem>, ISeq<TItem>> seqFactory,
             Func<CancellationToken, Task<IEnumerable<TItem>>> loadDataAsync = null,
@@ -20,6 +41,8 @@ namespace Async.Model.AsyncLoaded
         {
             // Do nothing: base constructor handles everything
         }
+
+        // TODO: Move all event notification out of the lock scope to minimize contention
 
         public override TItem Take()
         {
@@ -39,46 +62,58 @@ namespace Async.Model.AsyncLoaded
 
         public override void Replace(TItem oldItem, TItem newItem)
         {
+            var comparer = EqualityComparer<TItem>.Default;
+            ItemChange<TItem>[] changes;
+
             using (mutex.Lock())
             {
-                seq.Replace(oldItem, newItem);
-                NotifyCollectionChanged(ChangeType.Updated, newItem);
+                // NOTE: Cannot use LinqExtensions.Replace here, since we need to know which items
+                // were replaced for event notifications
+                changes = seq.Select(item =>
+                {
+                    if (comparer.Equals(item, oldItem))
+                        return new ItemChange<TItem>(ChangeType.Updated, newItem);
+                    else
+                        return new ItemChange<TItem>(ChangeType.Unchanged, item);
+                }).ToArray();
+
+                // Perform replacement
+                seq.ReplaceAll(changes.Select(c => c.Item));
             }
+
+            NotifyCollectionChanged(changes.Where(c => c.Type == ChangeType.Updated).ToArray());
         }
 
         public override void ReplaceAll(IEnumerable<TItem> newItems)
         {
+            ItemChange<TItem>[] changes;
+
             using (mutex.Lock())
             {
+                // Be conservative when checking for updated items
+                // NOTE: This will generate updates for unchanged items, which should not be a correctness problem
+                changes = newItems.ChangesFrom(seq, updateComparer: conservativeUpdateComparer)
+                    .ToArray();  // must materialize before we change seq
+
                 seq.ReplaceAll(newItems);
-
-                // TODO: This will generate updates for unchanged items, is this acceptable?
-                var changes = newItems.ChangesFrom(seq, i => i, i => i, EqualityComparer<TItem>.Default, new NeverEqualsComparer<TItem>());
-                NotifySpecialOperationCompleted(changes);
-            }
-        }
-
-        class NeverEqualsComparer<T> : EqualityComparer<T>
-        {
-            public override bool Equals(T x, T y)
-            {
-                return false;
             }
 
-            public override int GetHashCode(T obj)
-            {
-                return obj.GetHashCode();
-            }
+            NotifyCollectionChanged(changes);
         }
 
         public override void Clear()
         {
+            ItemChange<TItem>[] changes;
+
             using (mutex.Lock())
             {
-                var changes = seq.Select(item => new ItemChange<TItem>(ChangeType.Removed, item)).ToArray();
+                changes = seq.Select(item => new ItemChange<TItem>(ChangeType.Removed, item))
+                    .ToArray();  // must materialize before we change seq
+
                 seq.Clear();
-                NotifySpecialOperationCompleted(changes);
             }
+
+            NotifyCollectionChanged(changes);
         }
 
         public override IEnumerator<TItem> GetEnumerator()

--- a/Async.Model/ItemChange.cs
+++ b/Async.Model/ItemChange.cs
@@ -29,5 +29,10 @@
                 return type.GetHashCode() + 7 * item.GetHashCode();
             }
         }
+
+        public override string ToString()
+        {
+            return string.Format("ItemChange({0:G}, {1})", type, item);
+        }
     }
 }

--- a/Async.Model/LinqExtensions.cs
+++ b/Async.Model/LinqExtensions.cs
@@ -88,38 +88,78 @@ namespace Async.Model
                         yield return resultSelector(leftValue, rightValue, key);
         }
 
-        public static IEnumerable<ItemChange<TKey>> ChangesFrom<TNew, TOld, TKey>(
-            this IEnumerable<TNew> newItems,
-            IEnumerable<TOld> oldItems,
-            Func<TNew, TKey> newItemKeySelector,
-            Func<TOld, TKey> oldItemKeySelector,
-            IEqualityComparer<TKey> identityComparer = null,
-            IEqualityComparer<TKey> updateComparer = null)
+        /// <summary>
+        /// Calculates the changes between the new sequence and the old sequence and returns the
+        /// result as a sequence of <see cref="ItemChange{T}"/>. Item ordering is ignored, so the
+        /// two sequences are effectively treated as mathematical sets.
+        /// </summary>
+        /// <typeparam name="TSource">The type of items in <paramref name="newItems"/> and <paramref name="oldItems"/>.</typeparam>
+        /// <param name="newItems">The input sequence of new items.</param>
+        /// <param name="oldItems">The input sequence of old items to calculate changes against.</param>
+        /// <param name="identityComparer">The <see cref="IEqualityComparer{T}"/> to use when determining if two items are versions of the same logical object.</param>
+        /// <param name="updateComparer">The <see cref="IEqualityComparer{T}"/> to use when determining if two items are the same version of the same logical object.</param>
+        /// <returns>A sequence of <see cref="ItemChange{T}"/> that describes all changes from the old sequence to the new.</returns>
+        public static IEnumerable<ItemChange<TSource>> ChangesFrom<TSource>(
+            this IEnumerable<TSource> newItems,
+            IEnumerable<TSource> oldItems,
+            IEqualityComparer<TSource> identityComparer = null,
+            IEqualityComparer<TSource> updateComparer = null)
         {
             if (newItems == null) throw new ArgumentNullException("newItems");
             if (oldItems == null) throw new ArgumentNullException("oldItems");
-            if (newItemKeySelector == null) throw new ArgumentNullException("newItemKeySelector");
-            if (oldItemKeySelector == null) throw new ArgumentNullException("oldItemKeySelector");
 
-            identityComparer = identityComparer ?? EqualityComparer<TKey>.Default;
-            updateComparer = updateComparer ?? EqualityComparer<TKey>.Default;
+            identityComparer = identityComparer ?? EqualityComparer<TSource>.Default;
+            updateComparer = updateComparer ?? EqualityComparer<TSource>.Default;
 
-            return newItems.FullOuterJoin(oldItems, newItemKeySelector, oldItemKeySelector, (n, o, k) =>
+            return ChangesFromIterator(newItems, oldItems, identityComparer, updateComparer);
+        }
+
+        internal static IEnumerable<ItemChange<T>> ChangesFromIterator<T>(
+            IEnumerable<T> newItems,
+            IEnumerable<T> oldItems,
+            IEqualityComparer<T> identityComparer,
+            IEqualityComparer<T> updateComparer)
+        {
+            // Ensure fast lookup of items
+            Dictionary<T, T> newDict = null;
+            Dictionary<T, T> oldDict = null;
+
+            try
             {
-                if (n == null)
-                    return new ItemChange<TKey>(ChangeType.Removed, k);
-                else if (o == null)
-                    return new ItemChange<TKey>(ChangeType.Added, k);
+                newDict = newItems.ToDictionary(item => item, identityComparer);
+                oldDict = oldItems.ToDictionary(item => item, identityComparer);
+            }
+            catch (ArgumentException)
+            {
+                // We will get an ArgumentException in case of duplicates in newItems or oldItems
 
-                var newKey = newItemKeySelector(n);
-                var oldKey = oldItemKeySelector(o);
+                // If newDict has not been set, then newItems caused the error, otherwise it must be oldItems
+                // TODO: Use nameof operator when we upgrade to C# 6.0
+                var argumentName = (newDict == null) ? "newItems" : "oldItems";
+                throw new ArgumentException("Duplicates not allowed", argumentName);
+            }
 
-                if (!updateComparer.Equals(newKey, oldKey))
-                    return new ItemChange<TKey>(ChangeType.Updated, newKey);
+            // Make a pass through the old items to find updates and removals
+            foreach (var oldItem in oldDict.Keys)
+            {
+                if (newDict.ContainsKey(oldItem))
+                {
+                    var newItem = newDict[oldItem];
+                    if (!updateComparer.Equals(newItem, oldItem))
+                        yield return new ItemChange<T>(ChangeType.Updated, newItem);
+                }
+                else
+                {
+                    yield return new ItemChange<T>(ChangeType.Removed, oldItem);
+                }
+            }
 
-                return new ItemChange<TKey>(ChangeType.Unchanged, newKey);
-
-            }, identityComparer);
+            // Make a pass through the new items to find additions
+            foreach (var newItem in newDict.Keys)
+            {
+                if (!oldDict.ContainsKey(newItem))
+                    yield return new ItemChange<T>(ChangeType.Added, newItem);
+            }
         }
     }
 }

--- a/Async.Model/Properties/AssemblyInfo.cs
+++ b/Async.Model/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.4")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta3")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta4")]


### PR DESCRIPTION
- add: separate project for test extensions that we want to use from other projects
- add: tests for the implementations of ISeq.Replace in the Seq class
- add: a bunch of tests for ThreadSafeAsyncLoader
- add: more tests for AsyncLoader
- add: a bunch of tests for LinqExtensions.ChangesFrom
- add: FluentAssertionsExtensions with extra assertions for item changes
- change: LoadAsync and UpdateAsync in IAsyncCollectionLoader now returns a task representing the overall operation that can be awaited
- fix: rewrote ThreadSafeAsyncLoader.Replace to properly handle change notification
- fix: must calculate changes BEFORE making them in method ThreadSafeAsyncLoader.ReplaceAll
- fix: ThreadSafeAsyncLoader emitted change notifications when no changes were made
- fix: AsyncLoader.LoadAsync did not notify about the clearing of the loader
- fix/change: rewrote LinqExtensions.ChangesFrom to remove limitation that the type of elements in the collections had to be nullable
