### PR TITLE
[TSS-297] Use SynchronizationContext for events in AsyncLoaderBase

### DIFF
--- a/Async.Model.TestExtensions/Properties/AssemblyInfo.cs
+++ b/Async.Model.TestExtensions/Properties/AssemblyInfo.cs
@@ -23,8 +23,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta5")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta6")]

--- a/Async.Model.UnitTest/AsyncLoaded/ThreadSafeAsyncLoaderTest.cs
+++ b/Async.Model.UnitTest/AsyncLoaded/ThreadSafeAsyncLoaderTest.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Schedulers;
 using Async.Model.AsyncLoaded;
+using Async.Model.Context;
 using Async.Model.Sequence;
 using Async.Model.TestExtensions;
 using FluentAssertions;
+using Nito.AsyncEx;
 using NSubstitute;
 using NUnit.Framework;
 // Because noone wants to type out this every time...
@@ -78,9 +80,12 @@ namespace Async.Model.UnitTest.AsyncLoaded
         public void ReplaceNotifiesOfChange()
         {
             IEnumerable<int> loadedInts = new[] { 2 };
-            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, loadDataAsync: tok => Task.FromResult(loadedInts),
-                eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventContext: new RunInlineSynchronizationContext());
+
+            loader.LoadAsync();  // load initial items
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
@@ -97,9 +102,12 @@ namespace Async.Model.UnitTest.AsyncLoaded
         public void ReplaceNotifiesOfEveryChangeMade()
         {
             IEnumerable<int> loadedInts = new[] { 2, 2, 2, 2 };
-            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, loadDataAsync: tok => Task.FromResult(loadedInts),
-                eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+            var loader = new ThreadSafeAsyncLoader<int>(
+                Seq.ListBased,
+                loadDataAsync: tok => Task.FromResult(loadedInts),
+                eventContext: new RunInlineSynchronizationContext());
+
+            loader.LoadAsync();  // load initial items
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
@@ -115,7 +123,7 @@ namespace Async.Model.UnitTest.AsyncLoaded
         [Test]
         public void ReplaceDoesNotNotifyIfLoaderIsEmpty()
         {
-            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, eventScheduler: new CurrentThreadTaskScheduler());
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, eventContext: new RunInlineSynchronizationContext());
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
 
@@ -134,7 +142,7 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(initialValues),
-                eventScheduler: new CurrentThreadTaskScheduler());
+                eventContext: new RunInlineSynchronizationContext());
             loader.LoadAsync();  // load initial values
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
@@ -173,8 +181,8 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(loadedInts),
-                eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+                eventContext: new RunInlineSynchronizationContext());
+            loader.LoadAsync();  // load initial values
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
@@ -212,8 +220,8 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(loadedInts),
-                eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+                eventContext: new RunInlineSynchronizationContext());
+            loader.LoadAsync();  // load initial values
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
@@ -241,8 +249,8 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(loadedInts),
-                eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+                eventContext: new RunInlineSynchronizationContext());
+            loader.LoadAsync();  // load initial values
 
 
             // --- Perform ---
@@ -264,8 +272,8 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(loadedInts),
-                eventScheduler: new CurrentThreadTaskScheduler());
-            loader.LoadAsync();
+                eventContext: new RunInlineSynchronizationContext());
+            loader.LoadAsync();  // load initial values
 
 
             // --- Perform ---
@@ -294,7 +302,7 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(initialValues),
-                eventScheduler: new CurrentThreadTaskScheduler());
+                eventContext: new RunInlineSynchronizationContext());
             loader.LoadAsync();  // load initial values
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
@@ -318,7 +326,7 @@ namespace Async.Model.UnitTest.AsyncLoaded
             var loader = new ThreadSafeAsyncLoader<int>(
                 Seq.ListBased,
                 loadDataAsync: tok => Task.FromResult(initialValues),
-                eventScheduler: new CurrentThreadTaskScheduler());
+                eventContext: new RunInlineSynchronizationContext());
             loader.LoadAsync();  // load initial values
 
             var listener = Substitute.For<CollectionChangedHandler<int>>();
@@ -335,7 +343,7 @@ namespace Async.Model.UnitTest.AsyncLoaded
         [Test]
         public void ClearDoesNotNotifyIfNoChangesWereMade()
         {
-            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, eventScheduler: new CurrentThreadTaskScheduler());
+            var loader = new ThreadSafeAsyncLoader<int>(Seq.ListBased, eventContext: new RunInlineSynchronizationContext());
             var listener = Substitute.For<CollectionChangedHandler<int>>();
             loader.CollectionChanged += listener;
 

--- a/Async.Model.UnitTest/Properties/AssemblyInfo.cs
+++ b/Async.Model.UnitTest/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta5")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta6")]

--- a/Async.Model/Async.Model.csproj
+++ b/Async.Model/Async.Model.csproj
@@ -40,6 +40,8 @@
     <Compile Include="AsyncLoaded\IAsyncCollectionLoader.cs" />
     <Compile Include="AsyncLoaded\ThreadSafeAsyncLoader.cs" />
     <Compile Include="AsyncLoader.cs" />
+    <Compile Include="Context\RunInlineSynchronizationContext.cs" />
+    <Compile Include="Context\TaskSchedulerSynchronizationContext.cs" />
     <Compile Include="IAsyncCollection.cs" />
     <Compile Include="EntityTag.cs" />
     <Compile Include="AsyncLoaded\IAsyncItem.cs" />

--- a/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
+++ b/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
@@ -37,7 +37,7 @@ namespace Async.Model.AsyncLoaded
             Func<CancellationToken, Task<IEnumerable<TItem>>> loadDataAsync = null,
             Func<IEnumerable<TItem>, CancellationToken, Task<IEnumerable<ItemChange<TItem>>>> fetchUpdatesAsync = null,
             CancellationToken rootCancellationToken = default(CancellationToken),
-            TaskScheduler eventScheduler = null) : base(seqFactory, loadDataAsync, fetchUpdatesAsync, rootCancellationToken, eventScheduler)
+            SynchronizationContext eventContext = null) : base(seqFactory, loadDataAsync, fetchUpdatesAsync, rootCancellationToken, eventContext)
         {
             // Do nothing: base constructor handles everything
         }

--- a/Async.Model/AsyncLoader.cs
+++ b/Async.Model/AsyncLoader.cs
@@ -26,7 +26,7 @@ namespace Async.Model
             Func<CancellationToken, Task<IEnumerable<TItem>>> loadDataAsync = null,
             Func<IEnumerable<TItem>, CancellationToken, Task<IEnumerable<ItemChange<TItem>>>> fetchUpdatesAsync = null,
             CancellationToken rootCancellationToken = default(CancellationToken),
-            TaskScheduler eventScheduler = null) : base(eventScheduler, rootCancellationToken)
+            SynchronizationContext eventContext = null) : base(eventContext, rootCancellationToken)
         {
             this.loadDataAsync = loadDataAsync;
             this.fetchUpdatesAsync = fetchUpdatesAsync;
@@ -85,7 +85,7 @@ namespace Async.Model
 
             return PerformAsyncOperation(() => { }, token => fetchUpdatesAsync(seq, token), PerformUpdatesInsideLock);
         }
-        #endregion
+        #endregion IAsyncCollectionLoader API
 
         #region IAsyncSeq API
         public virtual IEnumerator<TItem> GetEnumerator()
@@ -159,7 +159,7 @@ namespace Async.Model
                 NotifyCollectionChanged(ChangeType.Added, item);
             }
         }
-        #endregion
+        #endregion IAsyncSeq API
 
         #region Task continuations
         private IEnumerable<ItemChange<TItem>> InsertLoadedDataInsideLock(IEnumerable<TItem> loadedData, CancellationToken cancellationToken)

--- a/Async.Model/Context/RunInlineSynchronizationContext.cs
+++ b/Async.Model/Context/RunInlineSynchronizationContext.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+
+namespace Async.Model.Context
+{
+    /// <summary>
+    /// A <see cref="SynchronizationContext"/> that will execute all callbacks inline on the current thread. Among
+    /// other things, this is very useful for testing scenarios, since you can often avoid complicated synchronization
+    /// by using this class.
+    /// <remarks>Note that this class intentionally breaks the contract of
+    /// <see cref="SynchronizationContext.Post(SendOrPostCallback, object)"/>, since the callback will be executed
+    /// synchronously rather than asynchronously.</remarks>
+    /// </summary>
+    public sealed class RunInlineSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            d(state);
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            d(state);
+        }
+    }
+}

--- a/Async.Model/Context/TaskSchedulerSynchronizationContext.cs
+++ b/Async.Model/Context/TaskSchedulerSynchronizationContext.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Nito.AsyncEx;
+using Nito.AsyncEx.Synchronous;
+
+namespace Async.Model.Context
+{
+    /// <summary>
+    /// A <see cref="SynchronizationContext"/> that schedules posted callbacks to an underlying
+    /// <see cref="TaskScheduler"/>.
+    /// <remarks>Depending on the used task scheduler, the contract of <see cref="Post(SendOrPostCallback, object)"/>
+    /// may be breached. For example, using <c>CurrentThreadTaskScheduler</c> from Parallel Extensions Extras
+    /// (http://blogs.msdn.com/b/pfxteam/archive/2010/04/09/9990424.aspx) will cause posted callbacks to be executed
+    /// synchronously inline on the current thread instead of asynchronously.</remarks>
+    /// </summary>
+    public sealed class TaskSchedulerSynchronizationContext : SynchronizationContext
+    {
+        /// <summary>A <see cref="TaskFactory"/> used to run tasks on the underlying <see cref="TaskScheduler"/>.</summary>
+        private readonly TaskFactory taskFactory;
+
+        /// <summary>
+        /// Constructs a new <see cref="TaskSchedulerSynchronizationContext"/> that will execute posted and sent 
+        /// callbacks on the given <see cref="TaskScheduler"/> instance.
+        /// </summary>
+        /// <param name="taskScheduler">The task scheduler to execute tasks on.</param>
+        public TaskSchedulerSynchronizationContext(TaskScheduler taskScheduler)
+        {
+            this.taskFactory = new TaskFactory(taskScheduler);
+        }
+
+        /// <summary>
+        /// Executes the given callback as a task on the underlying <see cref="TaskScheduler"/>. See
+        /// <see cref="SynchronizationContext.Post(SendOrPostCallback, object)"/> for further details.
+        /// </summary>
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            taskFactory.Run(() => d(state));
+        }
+
+        /// <summary>
+        /// Executes the given callback as a task on the underlying <see cref="TaskScheduler"/> and waits for its
+        /// completion. Unwraps any exception thrown. See
+        /// <see cref="SynchronizationContext.Send(SendOrPostCallback, object)"/> for further details.
+        /// </summary>
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            var task = taskFactory.Run(() => d(state));
+            task.WaitAndUnwrapException();
+        }
+    }
+}

--- a/Async.Model/Properties/AssemblyInfo.cs
+++ b/Async.Model/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta5")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta6")]


### PR DESCRIPTION
- refactor: use a SynchronizationContext instead of a TaskScheduler for
  performing event notifications in AsyncLoaderBase; this will avoid
  exceptions thrown from event handlers to go unobserved
- add: bonus tests for AsyncLoader.UpdateAsync
- add: RunInlineSynchronizationContext that can be used to ease testing by
  executing posted callbacks inline on current thread
- add: TaskSchedulerSynchronizationContext that will execute callbacks posted
  on the sync context as tasks on the associated TaskScheduler
