### PR TITLE
TSS-296 excessive updates

### DIFF
--- a/Async.Model/Async.Model.csproj
+++ b/Async.Model/Async.Model.csproj
@@ -59,10 +59,6 @@
       <HintPath>..\packages\Nito.AsyncEx.3.0.1-zhivepeople\lib\portable-net45+netcore45+wp8+wpa81\Nito.AsyncEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
+++ b/Async.Model/AsyncLoaded/ThreadSafeAsyncLoader.cs
@@ -30,16 +30,20 @@ namespace Async.Model.AsyncLoaded
             }
         }
 
-        private static readonly ConservativeUpdateComparer<TItem> conservativeUpdateComparer = new ConservativeUpdateComparer<TItem>();
+        private readonly IEqualityComparer<TItem> updateComparer;
 
         public ThreadSafeAsyncLoader(
             Func<IEnumerable<TItem>, ISeq<TItem>> seqFactory,
             Func<CancellationToken, Task<IEnumerable<TItem>>> loadDataAsync = null,
             Func<IEnumerable<TItem>, CancellationToken, Task<IEnumerable<ItemChange<TItem>>>> fetchUpdatesAsync = null,
+            IEqualityComparer<TItem> identityComparer = null,
+            IEqualityComparer<TItem> updateComparer = null,
             CancellationToken rootCancellationToken = default(CancellationToken),
-            SynchronizationContext eventContext = null) : base(seqFactory, loadDataAsync, fetchUpdatesAsync, rootCancellationToken, eventContext)
+            SynchronizationContext eventContext = null) : base(seqFactory, loadDataAsync, fetchUpdatesAsync, identityComparer, rootCancellationToken, eventContext)
         {
-            // Do nothing: base constructor handles everything
+            // Default to conservative comparer when checking for updated items
+            // NOTE: This will generate updates for unchanged items, which should not be a correctness problem
+            this.updateComparer = updateComparer ?? new ConservativeUpdateComparer<TItem>();
         }
 
         // TODO: Move all event notification out of the lock scope to minimize contention
@@ -62,7 +66,6 @@ namespace Async.Model.AsyncLoaded
 
         public override void Replace(TItem oldItem, TItem newItem)
         {
-            var comparer = EqualityComparer<TItem>.Default;
             ItemChange<TItem>[] changes;
 
             using (mutex.Lock())
@@ -71,7 +74,7 @@ namespace Async.Model.AsyncLoaded
                 // were replaced for event notifications
                 changes = seq.Select(item =>
                 {
-                    if (comparer.Equals(item, oldItem))
+                    if (identityComparer.Equals(item, oldItem))
                         return new ItemChange<TItem>(ChangeType.Updated, newItem);
                     else
                         return new ItemChange<TItem>(ChangeType.Unchanged, item);
@@ -81,7 +84,7 @@ namespace Async.Model.AsyncLoaded
                 seq.ReplaceAll(changes.Select(c => c.Item));
             }
 
-            NotifyCollectionChanged(changes.Where(c => c.Type == ChangeType.Updated).ToArray());
+            NotifyCollectionChanged(changes.Where(c => c.Type == ChangeType.Updated));
         }
 
         public override void ReplaceAll(IEnumerable<TItem> newItems)
@@ -90,15 +93,13 @@ namespace Async.Model.AsyncLoaded
 
             using (mutex.Lock())
             {
-                // Be conservative when checking for updated items
-                // NOTE: This will generate updates for unchanged items, which should not be a correctness problem
-                changes = newItems.ChangesFrom(seq, updateComparer: conservativeUpdateComparer)
+                changes = newItems.ChangesFrom(seq, identityComparer, updateComparer)
                     .ToArray();  // must materialize before we change seq
 
                 seq.ReplaceAll(newItems);
             }
 
-            NotifyCollectionChanged(changes);
+            NotifyCollectionChanged(changes.Where(c => c.Type != ChangeType.Unchanged));
         }
 
         public override void Clear()

--- a/Async.Model/AsyncLoader.cs
+++ b/Async.Model/AsyncLoader.cs
@@ -18,6 +18,7 @@ namespace Async.Model
         private readonly Func<IEnumerable<TItem>, CancellationToken, Task<IEnumerable<ItemChange<TItem>>>> fetchUpdatesAsync;
 
         protected readonly IAsyncSeq<TItem> seq;
+        protected readonly IEqualityComparer<TItem> identityComparer;
 
 
         public AsyncLoader(
@@ -25,6 +26,7 @@ namespace Async.Model
             Func<IEnumerable<TItem>, ISeq<TItem>> seqFactory,
             Func<CancellationToken, Task<IEnumerable<TItem>>> loadDataAsync = null,
             Func<IEnumerable<TItem>, CancellationToken, Task<IEnumerable<ItemChange<TItem>>>> fetchUpdatesAsync = null,
+            IEqualityComparer<TItem> identityComparer = null,
             CancellationToken rootCancellationToken = default(CancellationToken),
             SynchronizationContext eventContext = null) : base(eventContext, rootCancellationToken)
         {
@@ -38,6 +40,8 @@ namespace Async.Model
 
             this.seqFactory = asyncSeqFactory;
             this.seq = asyncSeqFactory(Enumerable.Empty<TItem>());
+
+            this.identityComparer = identityComparer ?? EqualityComparer<TItem>.Default;
         }
 
         #region IAsyncCollectionLoader API
@@ -182,8 +186,19 @@ namespace Async.Model
             // NOTE: We preserve any items from seq not found in fetchedUpdates, since they must have been Conj'ed
             var changes = seq
                 .FullOuterJoin(fetchedUpdates, i => i, u => u.Item,
-                    (i, u, k) => u ?? new ItemChange<TItem>(ChangeType.Unchanged, i))
+                    (i, u, k) => u ?? new ItemChange<TItem>(ChangeType.Unchanged, i), identityComparer)
                 .ToArray();  // materialize to prevent multiple enumerations of source
+
+            // TODO: What do we do about invalid item changes, such as update or removal of a non-existing item?
+            // We have several options:
+            // 1. We throw an exception. This has the advantage of helping to uncover bugs. But there are problems.
+            //    First, if we throw an exception directly in this method, it will be caught by AsyncLoaderBase and
+            //    treated as a failed async operation. To solve this, we could post a callback on the event
+            //    synchronization context that throws the exception on the UI thread. Second, treating these invalid
+            //    item changes as errors could turn otherwise benign race conditions into fatal errors.
+            // 2. We ignore the item change. This could make our code simpler, because we might not need as much
+            //    coordination between what happens in the UI and what happens in asynchronous background operations.
+            //    The disadvantage of this approach is that it could hide bugs.
 
             // Filter out removed items
             var newItems = changes
@@ -203,9 +218,9 @@ namespace Async.Model
             NotifySpecialOperationCompleted(changes);
         }
 
-        protected void NotifyCollectionChanged(ItemChange<TItem>[] changes)
+        protected void NotifyCollectionChanged(IEnumerable<ItemChange<TItem>> changes)
         {
-            if (changes.Length > 0)
+            if (changes.Any())
             {
                 // Only notify if actual changes were made
                 NotifySpecialOperationCompleted(changes);

--- a/Async.Model/AsyncLoader.cs
+++ b/Async.Model/AsyncLoader.cs
@@ -198,6 +198,9 @@ namespace Async.Model
             // 2. We ignore the item change. This could make our code simpler, because we might not need as much
             //    coordination between what happens in the UI and what happens in asynchronous background operations.
             //    The disadvantage of this approach is that it could hide bugs.
+            // 3. Do as now, ignore the problem. This has the advantage of simplicity. The problem is that updates to
+            //    non-existing items will result in the addition of those items, which is pretty confusing. Making
+            //    matters even worse, the additions are reported as updates in the CollectionChanged notification.
 
             // Filter out removed items
             var newItems = changes

--- a/Async.Model/AsyncLoader.cs
+++ b/Async.Model/AsyncLoader.cs
@@ -1,12 +1,11 @@
-﻿using Async.Model.AsyncLoaded;
-using Async.Model.Sequence;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Async.Model.AsyncLoaded;
+using Async.Model.Sequence;
 using Nito.AsyncEx;
 
 namespace Async.Model

--- a/Async.Model/packages.config
+++ b/Async.Model/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Nito.AsyncEx" version="3.0.1-zhivepeople" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
 </packages>


### PR DESCRIPTION
[TSS-296] Added optional identity and update comparers to async loaders
- add: AsyncLoader now takes optional identity comparer; this can be used to
  ensure correct operation when items don't implement IComparable/override
  Equals
- add: ThreadSafeAsyncLoader now takes optional identity and update comparers;
  the identity comparer can be used to ensure correct operation; the update
  comparer can be used for avoiding extraneous updates
- add: tests to show that ThreadSafeAsyncLoader uses the new comparers in
  Replace and ReplaceAll methods
- add: test to show that AsyncLoader uses identity comparer in UpdateAsync
- change: ThreadSafeAsyncLoader.ReplaceAll no longer emits item changes for
  unchanged items

[TSS-296] Removed unused dependency System.Collections.Immutable
- cleanup: main project still depended on nuget package
  System.Collections.Immutable even though it hasn't utilized any immutable
  collection API for quite some time

[TSS-296] Changed handling of exceptions in event handlers
- change: any exceptions coming from notifying event handlers now gets
  reflected in the overall task returned from
  AsyncLoaderBase.PerformAsyncOperation; this enables assertions in event
  handlers in tests
- add: test to show and verify new behaviour of AsyncLoaderBase
- fix: AsyncLoaderTest.UpdateAsyncUsesIdentityComparerGivenAtConstruction must
  check the raised event
