### PR TITLE
[TSS-360] Fixed wrapping of incoming seqs in AsyncLoader

### DIFF
--- a/Async.Model.TestExtensions/Properties/AssemblyInfo.cs
+++ b/Async.Model.TestExtensions/Properties/AssemblyInfo.cs
@@ -23,8 +23,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyVersion("1.0.0.8")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta7")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta8")]

--- a/Async.Model.UnitTest/Async.Model.UnitTest.csproj
+++ b/Async.Model.UnitTest/Async.Model.UnitTest.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\packages\Nito.AsyncEx.3.0.1-zhivepeople\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/Async.Model.UnitTest/Properties/AssemblyInfo.cs
+++ b/Async.Model.UnitTest/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyVersion("1.0.0.8")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta7")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta8")]

--- a/Async.Model.UnitTest/packages.config
+++ b/Async.Model.UnitTest/packages.config
@@ -3,7 +3,7 @@
   <package id="FluentAssertions" version="3.4.1" targetFramework="net45" />
   <package id="MSFT.ParallelExtensionsExtras" version="1.2.0" targetFramework="net45" />
   <package id="Nito.AsyncEx" version="3.0.1-zhivepeople" targetFramework="net45" />
-  <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
+  <package id="NSubstitute" version="1.9.2.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />

--- a/Async.Model/Properties/AssemblyInfo.cs
+++ b/Async.Model/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyVersion("1.0.0.8")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta7")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta8")]


### PR DESCRIPTION
- fix: AsyncLoader must not call AsAsync on the seq constructed from
  the given seq factory, if the seq is already async
