### PR TITLE
TSS-354 transient error handling

### DIFF
--- a/Async.Model/AsyncLoaded/AsyncItemLoader.cs
+++ b/Async.Model/AsyncLoaded/AsyncItemLoader.cs
@@ -4,14 +4,14 @@ using System.Threading.Tasks;
 
 namespace Async.Model.AsyncLoaded
 {
-    public sealed class AsyncItemLoader<T> : AsyncLoaderBase<Tuple<T, T>>, IAsyncItemLoader<T>
+    public sealed class AsyncItemLoader<TItem, TProgress> : AsyncLoaderBase<Tuple<TItem, TItem>>, IAsyncItemLoader<TItem, TProgress>
     {
-        private readonly Func<CancellationToken, Task<T>> loadAsync;
-        private readonly Func<T, CancellationToken, Task<T>> updateAsync;
+        private readonly Func<IProgress<TProgress>, CancellationToken, Task<TItem>> loadAsync;
+        private readonly Func<TItem, IProgress<TProgress>, CancellationToken, Task<TItem>> updateAsync;
 
-        private T item;
+        private TItem item;
 
-        public T Item
+        public TItem Item
         {
             get
             {
@@ -22,7 +22,7 @@ namespace Async.Model.AsyncLoaded
             }
         }
 
-        public event ItemChangedHandler<T> ItemChanged
+        public event ItemChangedHandler<TItem> ItemChanged
         {
             add
             {
@@ -37,26 +37,26 @@ namespace Async.Model.AsyncLoaded
             }
         }
 
-        public AsyncItemLoader(Func<CancellationToken, Task<T>> loadAsync, Func<T, CancellationToken, Task<T>> updateAsync, CancellationToken rootCancellationToken)
+        public AsyncItemLoader(Func<IProgress<TProgress>, CancellationToken, Task<TItem>> loadAsync, Func<TItem, IProgress<TProgress>, CancellationToken, Task<TItem>> updateAsync, CancellationToken rootCancellationToken)
             : base(rootCancellationToken)
         {
             this.loadAsync = loadAsync;
             this.updateAsync = updateAsync;
         }
 
-        public Task LoadAsync()
+        public Task LoadAsync(IProgress<TProgress> progress)
         {
             // TODO: Should we follow behaviour of AsyncLoader and clear item during load?
-            return PerformAsyncOperation(() => { }, loadAsync, ProcessItemUnderLock);
+            return PerformAsyncOperation(() => { }, tok => loadAsync(progress, tok), ProcessItemUnderLock);
         }
 
-        public Task UpdateAsync()
+        public Task UpdateAsync(IProgress<TProgress> progress)
         {
             var it = Item;  // read under lock
-            return PerformAsyncOperation(() => { }, token => updateAsync(it, token), ProcessItemUnderLock);
+            return PerformAsyncOperation(() => { }, tok => updateAsync(it, progress, tok), ProcessItemUnderLock);
         }
 
-        private Tuple<T, T> ProcessItemUnderLock(T newItem, CancellationToken cancellationToken)
+        private Tuple<TItem, TItem> ProcessItemUnderLock(TItem newItem, CancellationToken cancellationToken)
         {
             var oldItem = this.item;
             this.item = newItem;

--- a/Async.Model/AsyncLoaded/IAsyncItemLoader.cs
+++ b/Async.Model/AsyncLoaded/IAsyncItemLoader.cs
@@ -1,10 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Async.Model.AsyncLoaded
 {
-    public interface IAsyncItemLoader<T> : IAsyncItem<T>
+    public interface IAsyncItemLoader<TItem, TProgress> : IAsyncItem<TItem>
     {
-        Task LoadAsync();
-        Task UpdateAsync();
+        Task LoadAsync(IProgress<TProgress> progress);
+        Task UpdateAsync(IProgress<TProgress> progress);
     }
 }

--- a/Async.Model/Properties/AssemblyInfo.cs
+++ b/Async.Model/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyVersion("1.0.0.8")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-beta7")]
+[assembly: AssemblyInformationalVersion("1.0.0-beta8")]


### PR DESCRIPTION
- refactor: rename type parameter T -> TItem in IAsyncItemLoader and
  AsyncItemLoader in preparation of introducing new type parameter
  TProgress
- add: IAsyncItemLoader now takes an IProgress<TProgress> in the
  LoadAsync and UpdateAsync methods
- add: AsyncItemLoader now expects loader and update delegates that
  also take an IProgress<TProgress>, so that progress can be passed
  back to the caller
